### PR TITLE
Makefile flags (fixes #20)

### DIFF
--- a/src/wasm/modules/image/Makefile
+++ b/src/wasm/modules/image/Makefile
@@ -18,7 +18,11 @@ COMMON_FLAGS  := \
   -s ENVIRONMENT=web \
   -I$(INCLUDE_DIR) \
   -s EXPORTED_FUNCTIONS="['_malloc','_free']" \
-  -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap","getValue","setValue","HEAPU8"]'
+  -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap","getValue","setValue","HEAPU8"]' \
+  -s INITIAL_MEMORY=1024MB \
+  -s MAXIMUM_MEMORY=2048MB \
+  -s ALLOW_MEMORY_GROWTH=1 \
+  -s ASSERTIONS=2
 
 # Release vs Debug flags
 RELEASE_FLAGS := -O3 -s SINGLE_FILE=0

--- a/src/wasm/modules/image/src/image_utils.cpp
+++ b/src/wasm/modules/image/src/image_utils.cpp
@@ -107,7 +107,6 @@ extern "C" {
 	EMSCRIPTEN_KEEPALIVE
 		void kmeans_clustering(uint8_t* data, int width, int height, int k, int max_iter) {
 			int num_pixels = width * height;
-			std::cout << "width = " << width << "\nheight = " << height << "\nnum_pixels = " << num_pixels << std::endl;
 			std::vector<RGB> pixels(num_pixels);
 			std::vector<RGB> centroids(k);
 			std::vector<int> labels(num_pixels, 0);


### PR DESCRIPTION
# 🐛 Bugfix Pull Request
> Fix a bug or regression

## 📌 Bug Description
- **What was wrong**:
OOM errors due to high memory utilization when using kmeans_clustering().
- **Symptoms / Reproduction**:
Sufficiently large/complex images resulted in high memory consumption and would crash the program.

## 🔍 Root Cause
- Explanation of underlying issue:
The Emscripten compiler would not grow the program's available memory.

## ✅ Fix Summary
- What changed
The addition of flags for a larger initial memory and allowing the program's memory to grow.
- Why it solves the problem
The program will always have sufficiently large enough memory as required.

## 🔗 Issue
- Fixes: #20 

## 🧪 Regression Tests
- How you verified no other behaviors broke
Tested on multiple large images, and specifically the images that caused the issue.

## ✔️ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover the fix.
- [x] Lint/format checks pass.
- [x] Documentation updated if needed.

## 📸 Screenshots / Logs
