### PR TITLE
Fix: WASM Blocks Main Thread

### DIFF
--- a/src/hooks/useWasmWorker.js
+++ b/src/hooks/useWasmWorker.js
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+// React hook for interacting with the wasmWorker (a web worker)
+export function useWasmWorker() {
+	const workerRef = useRef(); // Current web worker instance
+	const idRef = useRef(0); // Unique ID counter for async responses (see call below)
+	const callbacks = useRef(new Map()); // Maps IDs to resolve/reject handlers
+
+	// initialize once
+	useEffect(() => {
+		workerRef.current = new Worker(new URL('@workers/wasmWorker.js', import.meta.url), { type: 'module' });
+
+		// Listen to messages from web worker
+		workerRef.current.onmessage = ({ data }) => {
+			const { id, error, output, returnValue } = data;
+			const cb = callbacks.current.get(id);
+			if (!cb) return;
+			// Handle promise based on ID
+			error ? cb.reject(error) : cb.resolve({ output, returnValue });
+			callbacks.current.delete(id);
+		};
+
+		return () => workerRef.current.terminate();
+	}, []);
+
+	// Send a task to the worker
+	const call = useCallback((funcName, args = {}, bufferKeys = []) => {
+		const id = idRef.current++;
+
+		return new Promise((resolve, reject) => {
+			callbacks.current.set(id, { resolve, reject });
+			workerRef.current.postMessage({ id, funcName, args, bufferKeys });
+		});
+	}, []);
+
+	return { call };
+}

--- a/src/workers/wasmWorker.js
+++ b/src/workers/wasmWorker.js
@@ -1,0 +1,62 @@
+import createImageModule from '@wasm-image';
+
+let wasmModule;
+let readyResolve;
+const readyPromise = new Promise((res) => (readyResolve = res));
+
+// Initialize the module once
+createImageModule().then((mod) => {
+	wasmModule = mod;
+	readyResolve();
+});
+
+self.onmessage = async ({ data }) => {
+	// Wait until module is ready
+	await readyPromise;
+
+	const { id, funcName, args, bufferKeys } = data;
+
+	const pointers = {}; // Array of pointers, declared here to guarantee freeing in finally block
+	try {
+		// Allocate buffers for any Array payloads
+		if (bufferKeys) {
+			for (const key of bufferKeys) {
+				const arr = args[key]; // Get the buffer from args based on the key
+				const size = arr.length;
+				const ptr = wasmModule._malloc(size); // Allocate memory the same size as the buffer
+				wasmModule.HEAPU8.set(arr, ptr); // Place the buffer in the newly allocated memory
+				pointers[key] = { ptr, size };
+				args[key] = ptr; // Change to pass a pointer as an arg
+			}
+		}
+
+		// Dynamic function lookup (Emscripten exports are prefixed with '_')
+		const exportName = `_${funcName}`;
+		if (typeof wasmModule[exportName] !== 'function') {
+			throw new Error(`WASM export not found: ${exportName}`);
+		}
+
+		// Call the function with spread args
+		const targetFunction = wasmModule[exportName]; // Identify the function to call
+		const targetFunctionArgs = funcName && args ? Object.values(args) : []; // Prepare arguments to pass to function
+		const result = targetFunction(...targetFunctionArgs); // Call the function
+
+		// Retrieve buffers back
+		const outputs = {};
+		if (bufferKeys) {
+			for (const key of bufferKeys) {
+				const { ptr, size } = pointers[key];
+				outputs[key] = new Uint8ClampedArray(wasmModule.HEAPU8.subarray(ptr, ptr + size)); // Get data from buffer
+			}
+		}
+
+		self.postMessage({ id, output: outputs, returnValue: result });
+	} catch (error) {
+		self.postMessage({ id, error: error.message });
+	} finally {
+		// Always free pointers
+		for (const { ptr } of Object.values(pointers)) {
+			wasmModule._free(ptr);
+		}
+	}
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -44,6 +44,8 @@ export default defineConfig({
 			'@assets': path.resolve(__dirname, 'src/assets'),
 			'@components': path.resolve(__dirname, 'src/components'),
 			'@utils': path.resolve(__dirname, 'src/utils'),
+			'@hooks': path.resolve(__dirname, 'src/hooks'),
+			'@workers': path.resolve(__dirname, 'src/workers'),
 			...generateWasmAliases(), // in the form of '@wasm-{module}
 		}
 	},


### PR DESCRIPTION
# 🐛 Bugfix Pull Request
> Fix a bug or regression

## 📌 Bug Description
- **What was wrong**: WASM prevent execution of JS on main thread
- **Symptoms / Reproduction**: LetterGlitch component froze while WASM executed

## 🔍 Root Cause
- Explanation of underlying issue

## ✅ Fix Summary
- What changed
  - Switch to a web worker managed by a hook to offload WASM function calls to a separate thread
- Why it solves the problem
  - This allow the JS on the main thread to execute independently of the WASM

## 🔗 Issue
- Fixes: #31 

## 🧪 Regression Tests
- How you verified no other behaviors broke
  - No errors were thrown
  - The results were the same as expected
  - The underlying WASM calls remain the same

## ✔️ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md).
- [x] Tests cover the fix.
- [x] Lint/format checks pass.
- [x] Documentation updated if needed.

## 📸 Screenshots / Logs