### PR TITLE
fix(img2num scripts): change image ref to ryanmillard/img2num-dev:latest

### DIFF
--- a/img2num
+++ b/img2num
@@ -66,7 +66,7 @@ case "$MODE" in
   down) docker compose down ;;
   purge|destroy)
     docker compose down --volumes --remove-orphans
-    [ "$MODE" = "destroy" ] && docker rmi img2num-dev:latest
+    [ "$MODE" = "destroy" ] && docker rmi ryanmillard/img2num-dev:latest
     ;;
 
   # Tail logs

--- a/img2num.ps1
+++ b/img2num.ps1
@@ -88,7 +88,7 @@ switch ($Mode) {
     { $_ -in @("purge","destroy") } {
         docker compose down --volumes --remove-orphans
         if ($Mode -eq "destroy") {
-            docker rmi img2num-dev:latest
+            docker rmi ryanmillard/img2num-dev:latest
         }
     }
 


### PR DESCRIPTION
# 🐛 Bugfix Pull Request

> Fix a bug or regression

## 📌 Bug Description

- **What was wrong**: Invalid Docker image ref (`img2num-dev:latest`)
- **Symptoms / Reproduction**: Running the below:
```bash
./img2num destroy    # or the ps1 counterpart
```

## 🔍 Root Cause

Wrong image name

## ✅ Fix Summary

- Changed to use `ryanmillard/img2num-dev:latest` to match remote image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configuration to use fully qualified image references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->