### PR TITLE
fix(docs): add trailing slash to canonical URLs for Algolia crawler

### DIFF
--- a/docs/docs/guidelines/pull-requests.md
+++ b/docs/docs/guidelines/pull-requests.md
@@ -9,7 +9,7 @@ sidebar_position: 6
 git checkout -b feat/your-feature
 ```
 ## Make commits following guidelines
-These can be found in the [previous section](./commits).
+These can be found in the [previous section](../commits).
 
 ## Push to your fork:
 :::danger Danger: **Merge Conflicts**

--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -556,5 +556,5 @@ This section will help you run both the main application and the documentation s
 </Tabs>
 
 ### Further Information
-You may want to have a look at the [Project Scripts section](../project-scripts/overview) now, but make sure that you understand and
-agree with Img2Num's [License](../license) and [guidelines](../category/guidelines) first.
+You may want to have a look at the [Project Scripts section](../../project-scripts/overview) now, but make sure that you understand and
+agree with Img2Num's [License](../../license) and [guidelines](../../category/guidelines) first.

--- a/docs/docs/reference/react/components/_category_.json
+++ b/docs/docs/reference/react/components/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Components",
-  "position": 1,
+  "position": 2,
   "link": {
     "type": "generated-index",
     "title": "React Components",

--- a/docs/docs/reference/react/overview.md
+++ b/docs/docs/reference/react/overview.md
@@ -1,7 +1,8 @@
 ---
-title: React Documentation
+title: React Overview
 description: Detailed reference documentation for all Img2Num React.js code. Use this as a guide to understand, use, and contribute to the project's JavaScript and React codebase.
 keywords: [reference, API, JavaScript, React, Img2Num, documentation, developer guide]
+sidebar_position: 1
 ---
 
 # React Reference

--- a/docs/docs/reference/tools/overview.md
+++ b/docs/docs/reference/tools/overview.md
@@ -1,7 +1,8 @@
 ---
-title: Tools Documentation
+title: Tools Overview
 description: Detailed reference documentation for all Img2Num tooling code. Use this as a guide to understand, use, and contribute to the project's tooling codebase.
 keywords: [reference, API, tooling, cli Img2Num, documentation, developer guide]
+sidebar_position: 1
 ---
 
 # Tools Reference

--- a/docs/docs/reference/wasm/modules/image/fft_iterative/explained.md
+++ b/docs/docs/reference/wasm/modules/image/fft_iterative/explained.md
@@ -7,7 +7,7 @@ sidebar_position: 6
 # FFT — Iterative Implementation Explained
 
 This section explains the inner workings of the **iterative FFT** used in this project. It assumes you already understand Fourier theory, the DFT,
-and complex numbers (if not, [click here](./prerequisite-theory)).
+and complex numbers (if not, [click here](../prerequisite-theory)).
 Here we focus on **how the code works**, why each step is necessary, and why it was implemented in the way it was.
 
 ## Overview

--- a/docs/docs/reference/wasm/modules/image/fft_iterative/overview.md
+++ b/docs/docs/reference/wasm/modules/image/fft_iterative/overview.md
@@ -13,7 +13,7 @@ This section introduces the **iterative, radix-2, decimation-in-time (DIT) FFT**
 It focuses on how the algorithm is implemented, why each step is necessary,
 and where the corresponding code lives so you can jump straight into the implementation.
 
-If you need the mathematical background before diving in, see the prerequisite page: [Prerequisite theory](./prerequisite-theory/).
+If you need the mathematical background before diving in, see the prerequisite page: [Prerequisite theory](../prerequisite-theory/).
 
 ## At a glance
 
@@ -31,4 +31,4 @@ If you need the mathematical background before diving in, see the prerequisite p
 * **Implementation details** — step-by-step mapping between theory and the actual C++ code.
 * **API & reference** — brief function signatures and purpose for quick lookup.
 
-Jump to implementation: [Implementation details](./implementation/)
+Jump to implementation: [Implementation details](../implementation/)

--- a/docs/docs/reference/wasm/modules/overview.md
+++ b/docs/docs/reference/wasm/modules/overview.md
@@ -10,6 +10,6 @@ This section documents all WebAssembly modules in the project. Each module is se
 
 ## Available Modules
 
-- [Image](./image)
+- [Image](../image)
 
 More modules will appear here as the project grows.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -56,6 +56,9 @@ const config = {
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/Img2Num/info/',
 
+  // GitHub Pages fix: canonical URL with trailing slash
+  trailingSlash: true,
+
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'Ryan-Millard', // Usually your GitHub org/user name.


### PR DESCRIPTION
# 🐛 Bugfix Pull Request

> Fix a bug or regression

## 📌 Bug Description

- **What was wrong**: Algolia couldn't index the site since Docusaurus build without trailing slashes and GitHub Pages requires them as canonical
- **Symptoms / Reproduction**: Search for anything in Algolia Search on the live site

## 🔍 Root Cause

Poorly configured URLs - non-canonical

## ✅ Fix Summary

Build Docusaurus with trailing slashes, update all pages to conform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized documentation structure and updated internal navigation links for improved consistency
  * Refreshed documentation page titles and adjusted organization hierarchy to enhance navigation
  * Enhanced website URL consistency through trailing slash configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->