### PR TITLE
ci(pr-check): ignore dependabot's PR body

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -46,6 +46,8 @@ jobs:
             }
 
   body-check:
+    # Dependabot cannot be configured to meaningfully use a PR template
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## What was changed & why
CI update - ignore this body you're reading in CI when it is Dependabot because it can't be configured to use this template.

Fixes: none

## Changes
2 lines - an if-statement

## Testing & Verification

## Additional Resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PR validation workflow to accumulate validation errors and display consolidated feedback messages instead of failing on individual issues
  * Introduced automated workflow failure summary feature that posts detailed validation error information as comments on pull requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->