### PR TITLE
ci(gh-pages): fix deployment bug that cleared docs folder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,41 +28,37 @@ jobs:
       ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
       ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
 
-  deploy-react-app:
-    name: Deploy React App to GitHub Pages
-    needs: build-react-app
+  deploy:
+    name: Deploy site to GH Pages
+    needs: [build-react-app, build-docs]
     runs-on: ubuntu-latest
     steps:
       - name: Download React build artifacts
         uses: actions/download-artifact@v8
         with:
           name: react-build
-          path: ./react-dist
+          path: ./new-react-build
+
+      - name: Download Docs build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-build
+          path: ./new-docs-build
+
+      - name: Prepare built assets
+        run: |
+          mkdir -p ./new-build/info
+          # We could just mv, but cp keeps the structure and works like a log for debugging if necessary
+          cp -r ./new-react-build/* ./new-build
+          cp -r ./new-docs-build/* ./new-build/info
 
       - name: Deploy React App
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./react-dist
+          publish_dir: ./new-build
           user_name: "github-actions[bot]"
           user_email: "github-actions[bot]@users.noreply.github.com"
 
-  deploy-docs:
-    name: Deploy Documentation to GitHub Pages
-    needs: build-docs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Docs build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: docs-build
-          path: ./docs-dist
-
-      - name: Deploy Documentation
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-dist
-          destination_dir: info
-          user_name: "github-actions[bot]"
-          user_email: "github-actions[bot]@users.noreply.github.com"
+      - name: Clean temp folders
+        run: rm -rf ./new-react-build ./new-docs-build


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

Combine React app and docs deployment into a single job to prevent peaceiris/actions-gh-pages from overwriting the docs. Downloads both artifacts, merges them into one deploy folder (`/` for React, `/info` for docs), and deploys once to gh-pages. Temporary build folders are cleaned afterward.

Fixes: None
Nothing fixed because it was urgent.

## Changes

One workflow.

## Testing & Verification

We shall find out soon.

## Additional Resources

<!-- Extra information, e.g. screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated separate app and docs deployment jobs into a single unified deployment job.
  * Combined built assets into a single publishable package, placing documentation under a dedicated subfolder so both app and docs deploy together.
  * Added preparation and cleanup steps to manage temporary build artifacts during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->