### PR TITLE
fix(webgpu): increase buffer limit beyond 256MB

### DIFF
--- a/core/include/internal/gpu.h
+++ b/core/include/internal/gpu.h
@@ -200,6 +200,21 @@ class GPU {
                           << " Msg: " << err_msg << std::endl;
             });
 
+        // Set maximum possible device hardware memory
+        wgpu::Limits supportedLimits;
+        wgpu::Limits requiredLimits;
+        if (adapter.GetLimits(&supportedLimits)) {
+            // nominally the device Buffer limit is 256MB
+            
+            // Copy the adapter's physical limits over to your requested limits
+            requiredLimits = supportedLimits;
+            
+            std::cout << "maxBufferSize: " << requiredLimits.maxBufferSize << std::endl;
+            std::cout << "maxStorageBufferBindingSize: " << requiredLimits.maxStorageBufferBindingSize << std::endl;
+
+            deviceDesc.requiredLimits = &requiredLimits;
+        }
+
         adapter.RequestDevice(
             &deviceDesc,
             wgpu::CallbackMode::AllowProcessEvents,  // <--- ALLOW EVENTS

--- a/core/src/internal/kmeans_gpu.cpp
+++ b/core/src/internal/kmeans_gpu.cpp
@@ -176,7 +176,6 @@ void kMeansPlusPlusInitGpu(const ImageLib::Image<PixelT>& pixels,
         wgpu::ComputePassEncoder pass = encoder.BeginComputePass();
         pass.SetPipeline(pipeline);
         pass.SetBindGroup(0, bindGroup);
-        // pass.DispatchWorkgroups((num_pixels + 255) / 256, 1, 1);
         pass.DispatchWorkgroups((width + 15) / 16, (height + 15) / 16, 1);
         pass.End();
 

--- a/core/src/internal/kmeans_gpu.cpp
+++ b/core/src/internal/kmeans_gpu.cpp
@@ -176,7 +176,8 @@ void kMeansPlusPlusInitGpu(const ImageLib::Image<PixelT>& pixels,
         wgpu::ComputePassEncoder pass = encoder.BeginComputePass();
         pass.SetPipeline(pipeline);
         pass.SetBindGroup(0, bindGroup);
-        pass.DispatchWorkgroups((num_pixels + 255) / 256, 1, 1);
+        // pass.DispatchWorkgroups((num_pixels + 255) / 256, 1, 1);
+        pass.DispatchWorkgroups((width + 15) / 16, (height + 15) / 16, 1);
         pass.End();
 
         // C. Copy Result to ReadBuffer

--- a/core/src/internal/resources/dist_shader.wgsl
+++ b/core/src/internal/resources/dist_shader.wgsl
@@ -9,14 +9,19 @@ struct Params {
 };
 @group(0) @binding(2) var<uniform> params : Params;
 
-@compute @workgroup_size(256)
+@compute @workgroup_size(16, 16)
 fn main(@builtin(global_invocation_id) global_id : vec3<u32>) {
-    let index = global_id.x;
+    // let index = global_id.x;
     let width = params.width;
     
     // Map 1D Global ID to 2D Texture Coordinates
-    let y = index / width;
-    let x = index % width;
+    // let y = index / width;
+    // let x = index % width;
+
+    let x = global_id.x;
+    let y = global_id.y;
+
+    let index = params.width * y + x;
     
     let dims = textureDimensions(inputTex);
     if (x >= dims.x || y >= dims.y) { return; }


### PR DESCRIPTION
Helps with processing very large images.
1. Dist shader in kmeans++ had a 256 worker group size. Change to 16x16 to prevent >65536 workers dispatched at once.
2. Device maxBufferSize increased to maximum possible supported by gpu. Currently defaults to 256MB which causes a crash for very large images.

To test use this image:
![art002e000192](https://github.com/user-attachments/assets/51a23272-2271-4e85-8f10-d3816bdbb2f3)


<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
4. Your submission complies with our licensing, including attribution and redistribution rules.
5. All code, documentation, and other contributions are your original work or you have permission to submit them.
6. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

<!-- A sentence or two describing the change. -->
<!-- A brief motivation for this change -->

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: #<issue-number> <!-- use "Fixes: none" if no related issue -->

## Changes

<!-- A list of important changes -->

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized GPU compute workload distribution by switching to 2D dispatch for pixel processing, improving parallel efficiency.
  * Updated shader indexing to use direct 2D coordinates for faster, clearer memory access.
  * Improved GPU device initialization to query and apply adapter-supported limits for more reliable resource configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->