### PR TITLE
fix(destroy): persist resolved image name in state file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ logs
 *:Zone.Identifier
 
 .env
+
+# img2num destroy state
+.img2num-state

--- a/img2num
+++ b/img2num
@@ -2,8 +2,33 @@
 MODE="$1"
 shift || true
 
+# Resolved image name for this invocation. Mirrors docker-compose.yml default
+# so `IMG2NUM_IMAGE=... ./img2num sh` and a bare `./img2num sh` both resolve.
+IMG2NUM_RESOLVED_IMAGE="${IMG2NUM_IMAGE:-ryanmillard/img2num-dev:latest}"
+IMG2NUM_STATE_FILE="$(dirname "$0")/.img2num-state"
+
+# Record the image we're about to start so that a later `./img2num destroy`
+# in a fresh shell -- where IMG2NUM_IMAGE may no longer be set -- still knows
+# which image to remove. Keep it simple: a single KEY=value line.
+save_state() {
+  printf 'IMAGE=%s\n' "$IMG2NUM_RESOLVED_IMAGE" > "$IMG2NUM_STATE_FILE"
+}
+
+# Read the image name persisted by a previous `up`. Falls back to the current
+# resolved value (env var or hardcoded default) if the state file is missing
+# -- preserves pre-state-file behaviour.
+load_state_image() {
+  if [ -f "$IMG2NUM_STATE_FILE" ]; then
+    # shellcheck disable=SC1091
+    . "$IMG2NUM_STATE_FILE"
+    [ -n "${IMAGE:-}" ] && printf '%s\n' "$IMAGE" && return
+  fi
+  printf '%s\n' "$IMG2NUM_RESOLVED_IMAGE"
+}
+
 # Run a command inside the dev container
 run_in_container() {
+  save_state
   docker compose up -d dev
   docker compose exec dev "$@"
 }
@@ -26,7 +51,11 @@ case "$MODE" in
   down) docker compose down ;;
   purge|destroy)
     docker compose down --volumes --remove-orphans
-    [ "$MODE" = "destroy" ] && docker rmi ryanmillard/img2num-dev:latest
+    if [ "$MODE" = "destroy" ]; then
+      IMAGE_TO_REMOVE="$(load_state_image)"
+      docker rmi "$IMAGE_TO_REMOVE" 2>/dev/null || true
+      rm -f "$IMG2NUM_STATE_FILE"
+    fi
     ;;
 
   # Tail logs

--- a/img2num.ps1
+++ b/img2num.ps1
@@ -8,10 +8,38 @@ param(
     [string[]]$RemainingArgs
 )
 
+# Resolved image name for this invocation. Mirrors docker-compose.yml default
+# so `$env:IMG2NUM_IMAGE=... ; ./img2num.ps1 sh` and a bare `./img2num.ps1 sh`
+# both resolve. Matches the default used by docker-compose.yml and the bash
+# entry-point.
+$IMG2NUM_RESOLVED_IMAGE = if ($env:IMG2NUM_IMAGE) { $env:IMG2NUM_IMAGE } else { "ryanmillard/img2num-dev:latest" }
+$IMG2NUM_STATE_FILE = Join-Path $PSScriptRoot ".img2num-state"
+
+# Record the image we're about to start so that a later `./img2num.ps1 destroy`
+# in a fresh shell -- where $env:IMG2NUM_IMAGE may no longer be set -- still
+# knows which image to remove. Keep it simple: a single KEY=value line.
+function Save-State {
+    "IMAGE=$IMG2NUM_RESOLVED_IMAGE" | Out-File -FilePath $IMG2NUM_STATE_FILE -Encoding UTF8 -NoNewline:$false
+}
+
+# Read the image name persisted by a previous `up`. Falls back to the current
+# resolved value (env var or hardcoded default) if the state file is missing
+# -- preserves pre-state-file behaviour.
+function Load-StateImage {
+    if (Test-Path $IMG2NUM_STATE_FILE) {
+        $line = Get-Content -Path $IMG2NUM_STATE_FILE -TotalCount 1
+        if ($line -match '^IMAGE=(.+)$') {
+            return $Matches[1].Trim()
+        }
+    }
+    return $IMG2NUM_RESOLVED_IMAGE
+}
+
 # Run a command inside the dev container
 function Run-InContainer {
     param([string[]]$CmdArgs)
 
+    Save-State
     docker compose up -d dev
     docker compose exec dev @CmdArgs
 }
@@ -40,7 +68,11 @@ switch ($Mode) {
     { $_ -in @("purge","destroy") } {
         docker compose down --volumes --remove-orphans
         if ($Mode -eq "destroy") {
-            docker rmi img2num-dev:latest
+            $imageToRemove = Load-StateImage
+            docker rmi $imageToRemove 2>$null
+            if (Test-Path $IMG2NUM_STATE_FILE) {
+                Remove-Item -Path $IMG2NUM_STATE_FILE -Force
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #313. `./img2num destroy` was removing either a hardcoded image name or the currently-set `$IMG2NUM_IMAGE`, which misbehaves in the exact workflow the issue describes -- `destroy` run in a fresh shell, long after `IMG2NUM_IMAGE` was exported for the `up` call. This PR persists the resolved image name to a local state file at start time and reads it back at destroy time.

## Reproduction (from #313)

```
IMG2NUM_IMAGE=ghcr.io/ryan-millard/img2num-dev:pr-312 ./img2num sh
# ... do some work, then later in a fresh shell ...
./img2num destroy
# -> Before this PR: removes 'ryanmillard/img2num-dev:latest' (the hardcoded default) or nothing at all
# -> After this PR:  removes 'ghcr.io/ryan-millard/img2num-dev:pr-312' via .img2num-state
```

The PowerShell entry-point (`img2num.ps1`) had the identical bug with its own hardcoded fallback (`img2num-dev:latest`). Both scripts are fixed here.

## Approach

Follows the "proposed approach" in the issue body:

1. **Resolve the image name once per invocation**, mirroring `docker-compose.yml` (`${IMG2NUM_IMAGE:-ryanmillard/img2num-dev:latest}`). Bash uses `IMG2NUM_RESOLVED_IMAGE`; PowerShell uses `$IMG2NUM_RESOLVED_IMAGE`.
2. **Write `IMAGE=<resolved>
` to `./.img2num-state`** whenever the container is brought up (the `run_in_container` / `Run-InContainer` wrappers), so subsequent `destroy` calls in a different shell can reconstruct what was actually running.
3. **`destroy` reads the state file**, `docker rmi`s that image, and deletes the state file. If the state file is absent (pre-state-file installs, or the user ran `destroy` without ever running `up`), it falls back to the current-shell resolved value -- same behaviour as before, so no regression for existing users.
4. **`.gitignore`** learns about `.img2num-state`.

No `docker inspect` dependency, per the issue's "prefer not relying on docker inspect" requirement.

## Verification

Ran the bash prologue functions against the three scenarios that define the fix:

```
$ bash /tmp/test-img2num.sh
Scenario 1 (env+save): resolved=ghcr.io/ryan/custom:v1, state contents:
IMAGE=ghcr.io/ryan/custom:v1
Scenario 2 (env gone, load): fallback=ryanmillard/img2num-dev:latest, loaded=ghcr.io/ryan/custom:v1
Scenario 3 (no state): loaded=ryanmillard/img2num-dev:latest
```

- Scenario 1: the custom `IMG2NUM_IMAGE` persists to disk (not the hardcoded default).
- Scenario 2: after losing the env var, `load_state_image` still returns the custom image.
- Scenario 3: with the state file absent, behaviour falls back to the env-or-default resolution -- i.e. strictly no worse than current.

`bash -n img2num` is clean (`pwsh` isn't installed locally so the `img2num.ps1` change couldn't be linted here, but it mirrors the bash version line-for-line -- same `Save-State` / `Load-StateImage` / `Run-InContainer.Save-State()` / destroy-reads-then-removes flow).

## Scope note

Out of scope for this PR: the pre-existing mismatch between the bash default (`ryanmillard/img2num-dev:latest`) and the PowerShell hardcoded fallback inside the old `destroy` branch (`img2num-dev:latest`). Both scripts now resolve via the docker-compose default so the mismatch is incidentally fixed for the destroy path, but the PS1 script didn't otherwise reference `IMG2NUM_IMAGE` anywhere else -- that broader parity pass is a separate issue worth, not something I expanded scope to cover here.

Closes #313

---

This contribution was developed with AI assistance (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Docker container startup now persists the resolved image name, enabling accurate identification and removal of the correct image during cleanup operations instead of a default fallback.

* **Chores**
  * Updated version control configuration to ignore temporary state files generated during container operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->