### PR TITLE
fix(docker-ci): experimental permission check

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -2,9 +2,9 @@ name: Docker CI
 
 on:
   workflow_dispatch:
-  # pull_request:
-  # pull_request_target:
-  #   types: [opened, synchronize, reopened, closed]
+  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
 
   push:
     branches: [main]

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -25,6 +25,21 @@ jobs:
       cache_ref: ${{ steps.meta.outputs.cache_ref }}
 
     steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -2,9 +2,9 @@ name: Docker CI
 
 on:
   workflow_dispatch:
-  pull_request:
-  pull_request_target:
-    types: [opened, synchronize, reopened, closed]
+  # pull_request:
+  # pull_request_target:
+  #   types: [opened, synchronize, reopened, closed]
 
   push:
     branches: [main]

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,6 +1,7 @@
 name: Docker CI
 
 on:
+  pull_request:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
 
@@ -62,7 +63,7 @@ jobs:
           IMAGE="${{ env.IMAGE_NAME }}"
           EVENT="${{ github.event_name }}"
 
-          if [[ "$EVENT" == "pull_request_target" ]]; then
+          if [[ "$EVENT" == "pull_request*" ]]; then
             PR="${{ github.event.pull_request.number }}"
 
             CLEAN_CORE_TAG="pr-${PR}"
@@ -87,7 +88,8 @@ jobs:
           echo "cache_ref=$CACHE_REF" >> $GITHUB_OUTPUT
 
       - name: Build & Push Docker image
-        if: (github.event_name == 'pull_request_target' && github.event.action != 'closed') || github.event_name != 'pull_request'
+        # if: (github.event_name == 'pull_request_target' && github.event.action != 'closed') || github.event_name != 'pull_request'
+        if: (startsWith(github.event_name, 'pull_request') && github.event.action != 'closed') || !startsWith(github.event_name, 'pull_request')
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
@@ -102,7 +104,8 @@ jobs:
 
   notify:
     needs: build
-    if: github.event_name == 'pull_request_target' && needs.build.result == 'success'
+    # if: github.event_name == 'pull_request_target' && needs.build.result == 'success'
+    if: startsWith(github.event_name, 'pull_request') && needs.build.result == 'success'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,7 +1,7 @@
 name: Docker CI
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, closed]
 
   push:
@@ -33,6 +33,7 @@ jobs:
           username: ${{ github.triggering_actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check User Permission
         if: steps.checkAccess.outputs.require-result == 'false'
         run: |
@@ -40,6 +41,7 @@ jobs:
           echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
           echo "Job originally triggered by ${{ github.actor }}"
           exit 1
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,6 +1,7 @@
 name: Docker CI
 
 on:
+  workflow_dispatch:
   pull_request:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -62,7 +62,7 @@ jobs:
           IMAGE="${{ env.IMAGE_NAME }}"
           EVENT="${{ github.event_name }}"
 
-          if [[ "$EVENT" == "pull_request" ]]; then
+          if [[ "$EVENT" == "pull_request_target" ]]; then
             PR="${{ github.event.pull_request.number }}"
 
             CLEAN_CORE_TAG="pr-${PR}"
@@ -87,7 +87,7 @@ jobs:
           echo "cache_ref=$CACHE_REF" >> $GITHUB_OUTPUT
 
       - name: Build & Push Docker image
-        if: (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name != 'pull_request'
+        if: (github.event_name == 'pull_request_target' && github.event.action != 'closed') || github.event_name != 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
@@ -102,7 +102,7 @@ jobs:
 
   notify:
     needs: build
-    if: github.event_name == 'pull_request' && needs.build.result == 'success'
+    if: github.event_name == 'pull_request_target' && needs.build.result == 'success'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

Check proposal from https://michaelheap.com/access-secrets-from-forks/

## What was changed & why

<!-- A sentence or two describing the change. -->
<!-- A brief motivation for this change -->

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: #<issue-number> <!-- use "Fixes: none" if no related issue -->

## Changes

<!-- A list of important changes -->

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI trigger changed to a manual workflow run; previous pull-request triggers were commented out.
  * CI now performs an early permission check and aborts when the actor lacks required write permissions to prevent build/push steps.
  * Event-condition logic updated to consistently distinguish pull-request-like runs from non-pull-request runs; prior pull-request-target conditions were commented out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->