### PR TITLE
ci(pr-auto-label): fix file glob

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,7 +12,6 @@ docs:
       - "docs/**"
       - "**/*.md"
       - "**/*.dox"
-      - "!CHANGELOG.md"
 
 ci:
   - changed-files:


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

Fix the labeler workflow that applied `docs` to every PR.

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: #none

## Changes

Just removed the `!CHANGELOG` glob because things behave abnormally here.

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated GitHub labeling configuration to include changelog files in the documentation category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->