### PR TITLE
fix(build order): force ci to happen after docker-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 name: CI
 
+# on:
+#   pull_request:
+#     branches: [main]
+#   push:
+#     branches: [main]
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_call:
+    inputs:
+      ready:
+        required: true
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -204,6 +204,12 @@ jobs:
             type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ steps.meta.outputs.cache_ref }},mode=max
 
+  test:
+    needs: build
+    uses: ./.github/workflows/ci.yml
+    with:
+      ready: True
+
   notify:
     needs: [guard, build]
     if: github.event_name == 'issue_comment' && needs.build.result == 'success'


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

run docker-ci.yml first always, then ci.yml

## What was changed & why

<!-- A sentence or two describing the change. -->
<!-- A brief motivation for this change -->

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: #<issue-number> <!-- use "Fixes: none" if no related issue -->

## Changes

<!-- A list of important changes -->

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to enhance automation and testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->