### PR TITLE
ci(docker): fix image resolution for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
               --jq "any(.metadata.container.tags[]? == \"${PR_TAG}\")")
 
             DH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --connect-timeout 2 --max-time 5 \
               "https://registry.hub.docker.com/v2/repositories/ryan-millard/img2num-dev/tags/${PR_TAG}/")
           else
             GHCR_IMAGE_EXISTS="false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,29 +19,38 @@ jobs:
     steps:
       - name: Set image
         id: set
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           MAIN_IMAGE="ghcr.io/ryan-millard/img2num-dev:main"
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          REPO="ryan-millard/img2num-dev"
-          DH_IMAGE="${REPO}:${PR_TAG}"
-          GHCR_IMAGE="ghcr.io/${DH_IMAGE}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          GHCR_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
-            "https://ghcr.io/v2/ryan-millard/img2num-dev/manifests/${PR_TAG}")
+          if [[ -n "$PR_NUMBER" ]]; then
+            PR_TAG="pr-${PR_NUMBER}"
+            GHCR_IMAGE="ghcr.io/ryan-millard/img2num-dev:${PR_TAG}"
+            DH_IMAGE="ryan-millard/img2num-dev:${PR_TAG}"
 
-          DH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            "https://registry.hub.docker.com/v2/repositories/${REPO}/tags/${PR_TAG}/")
+            GHCR_IMAGE_EXISTS=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              /users/ryan-millard/packages/container/img2num-dev/versions \
+              --jq "any(.metadata.container.tags[]? == \"${PR_TAG}\")")
 
-          if [[ "$GHCR_STATUS" == "200" ]]; then
-            echo "image=${GHCR_IMAGE}"
-            echo "image=${GHCR_IMAGE}" >> $GITHUB_OUTPUT
-          elif [[ "$DH_STATUS" == "200" ]]; then
-            echo "image=${DH_IMAGE}"
-            echo "image=${DH_IMAGE}" >> $GITHUB_OUTPUT
+            DH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              "https://registry.hub.docker.com/v2/repositories/ryan-millard/img2num-dev/tags/${PR_TAG}/")
           else
-            echo "image=${MAIN_IMAGE}"
+            GHCR_IMAGE_EXISTS="false"
+            DH_STATUS="404"
+          fi
+
+          if [[ "$GHCR_IMAGE_EXISTS" == "true" ]]; then
+            echo "image=${GHCR_IMAGE}" >> $GITHUB_OUTPUT
+            echo "image=${GHCR_IMAGE}"
+          elif [[ "$DH_STATUS" == "200" ]]; then
+            echo "image=${DH_IMAGE}" >> $GITHUB_OUTPUT
+            echo "image=${DH_IMAGE}"
+          else
             echo "image=${MAIN_IMAGE}" >> $GITHUB_OUTPUT
+            echo "image=${MAIN_IMAGE}"
           fi
 
   lint:


### PR DESCRIPTION
  Previously the Docker image being used by CI always fell back to `main`. This is a problem if the PR edited the Dockerfile.

> [!IMPORTANT]
> This does not affect the first time opening the PR - a maintainer must still approve the build of the image before it can be used in CI. 

<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

Fixes the image resolution bug in `ci.yml` for PRs.

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: #none - see [this comment](https://github.com/Ryan-Millard/Img2Num/pull/307#issuecomment-4299591312) on #307.

## Changes

- `ci.yml`'s `set-image` job

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

See [the workflow run](https://github.com/Ryan-Millard/Img2Num/actions/runs/24802969437/job/72590087362?pr=322)

<img width="515" height="301" alt="image" src="https://github.com/user-attachments/assets/90b3eca6-665b-4ffe-a708-00070940f702" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline container image detection logic to provide more robust and reliable handling across deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->