### PR TITLE
fix(docker-ci): fix docker image cleanup after PR closure

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -248,36 +248,56 @@ jobs:
             IMG2NUM_IMAGE=${{ steps.img.outputs.ghcr_image }}:${{ env.CLEAN_CORE_TAG }} ./img2num sh
             ```
 
-  cleanup-on-close:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Delete PR images from GHCR
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55
-        with:
-          package-name: img2num-dev
-          package-type: container
-          num-old-versions-to-delete: 2 # delete the image and the cache
-          min-versions-to-keep: 0
-          ignore-versions: "^(?!pr-${{ github.event.pull_request.number }}$|cache-pr-${{ github.event.pull_request.number }}$).*"
+cleanup-on-close:
+  if: github.event_name == 'pull_request'
+  runs-on: ubuntu-latest
+  permissions:
+    packages: write
+  steps:
+    - name: Delete PR images from GHCR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR: ${{ github.event.pull_request.number }}
+        OWNER: ${{ github.repository_owner }}
+      run: |
+        for TAG in "pr-${PR}" "cache-pr-${PR}"; do
+          VERSION_ID=$(gh api \
+            "/user/packages/container/img2num-dev/versions" \
+            --paginate \
+            --jq ".[] | select(.metadata.container.tags[] == \"${TAG}\") | .id")
+          if [[ -n "$VERSION_ID" ]]; then
+            echo "Deleting version $VERSION_ID (tag: $TAG)"
+            gh api --method DELETE "/user/packages/container/img2num-dev/versions/${VERSION_ID}"
+          else
+            echo "No version found for tag: $TAG"
+          fi
+        done
 
-  cleanup-on-command:
-    needs: guard
-    if: |
-      needs.guard.result == 'success' &&
-      needs.guard.outputs.command == 'cleanup' &&
-      needs.guard.outputs.authorized == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Delete PR images from GHCR
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55
-        with:
-          package-name: img2num-dev
-          package-type: container
-          num-old-versions-to-delete: 2 # delete the image and the cache
-          min-versions-to-keep: 0
-          ignore-versions: "^(?!pr-${{ needs.guard.outputs.pr_number }}$|cache-pr-${{ needs.guard.outputs.pr_number }}$).*"
+cleanup-on-command:
+  needs: guard
+  if: |
+    needs.guard.result == 'success' &&
+    needs.guard.outputs.command == 'cleanup' &&
+    needs.guard.outputs.authorized == 'true'
+  runs-on: ubuntu-latest
+  permissions:
+    packages: write
+  steps:
+    - name: Delete PR images from GHCR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR: ${{ needs.guard.outputs.pr_number }}
+        OWNER: ${{ github.repository_owner }}
+      run: |
+        for TAG in "pr-${PR}" "cache-pr-${PR}"; do
+          VERSION_ID=$(gh api \
+            "/user/packages/container/img2num-dev/versions" \
+            --paginate \
+            --jq ".[] | select(.metadata.container.tags[] == \"${TAG}\") | .id")
+          if [[ -n "$VERSION_ID" ]]; then
+            echo "Deleting version $VERSION_ID (tag: $TAG)"
+            gh api --method DELETE "/user/packages/container/img2num-dev/versions/${VERSION_ID}"
+          else
+            echo "No version found for tag: $TAG"
+          fi
+        done


### PR DESCRIPTION
Previously failed to delete the images,
see https://github.com/Ryan-Millard/Img2Num/actions/runs/24804191793/job/72594225429.

<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

Cleanup job in `docker-ci.yml` was updated - lets hope it works.

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: #none - see [here](https://github.com/Ryan-Millard/Img2Num/actions/runs/24804191793/job/72594225429).

## Changes

Simple job update

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to refine container registry cleanup policies and improve workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->