### PR TITLE
refactor(core)!: update labels_to_svg to return std::string

### DIFF
--- a/bindings/c/include/cimg2num.h
+++ b/bindings/c/include/cimg2num.h
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/bindings/c/include/cimg2num.h
+++ b/bindings/c/include/cimg2num.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/bindings/c/src/cimg2num.cpp
+++ b/bindings/c/src/cimg2num.cpp
@@ -3,6 +3,8 @@
 #include "img2num.h"
 #include "img2num/Error.h"
 
+#include <string.h>
+
 extern "C" {
 
 void img2num_gaussian_blur_fft(uint8_t *image, size_t width, size_t height, double sigma) {

--- a/bindings/c/src/cimg2num.cpp
+++ b/bindings/c/src/cimg2num.cpp
@@ -3,7 +3,7 @@
 #include "img2num.h"
 #include "img2num/Error.h"
 
-#include <string.h>
+#include <cstring>
 
 extern "C" {
 
@@ -46,11 +46,11 @@ char *img2num_labels_to_svg(const uint8_t *data, const int32_t *labels, const in
     img2num::clear_last_error_and_catch(
         [&](const uint8_t *d, const int32_t *l, const int w, const int h, const int min_a) {
             std::string svg{img2num::labels_to_svg(d, l, w, h, min_a)};
-            result = static_cast<char *>(malloc(svg.size() + 1));
+            result = static_cast<char *>(std::malloc(svg.size() + 1));
             if (!result) {
                 return;  // Allocation failed
             }
-            memcpy(result, svg.c_str(), svg.size() + 1);
+            std::memcpy(result, svg.c_str(), svg.size() + 1);
         },
         data, labels, width, height, min_area);
     return result;

--- a/bindings/c/src/cimg2num.cpp
+++ b/bindings/c/src/cimg2num.cpp
@@ -43,7 +43,12 @@ char *img2num_labels_to_svg(const uint8_t *data, const int32_t *labels, const in
     char *result{nullptr};
     img2num::clear_last_error_and_catch(
         [&](const uint8_t *d, const int32_t *l, const int w, const int h, const int min_a) {
-            result = img2num::labels_to_svg(d, l, w, h, min_a);
+            std::string svg{img2num::labels_to_svg(d, l, w, h, min_a)};
+            result = static_cast<char *>(malloc(svg.size() + 1));
+            if (!result) {
+                return;  // Allocation failed
+            }
+            memcpy(result, svg.c_str(), svg.size() + 1);
         },
         data, labels, width, height, min_area);
     return result;

--- a/bindings/py/src/img2num_pybind.cpp
+++ b/bindings/py/src/img2num_pybind.cpp
@@ -112,20 +112,10 @@ PYBIND11_MODULE(_img2num, m) {
 
             const uint8_t* data_ptr{static_cast<const uint8_t*>(data.request().ptr)};
             const int32_t* labels_ptr{static_cast<const int32_t*>(labels.request().ptr)};
-            char* svg_c_str = img2num::labels_to_svg(data_ptr, labels_ptr, width, height, min_area);
-
-            if (!svg_c_str) {
-                throw std::runtime_error("img2num::labels_to_svg returned a null pointer.");
-            }
-
-            // Convert to Python string
-            pybind11::str svg_py_str(svg_c_str);
-
-            // NOTE: If your C library dynamically allocates this string using malloc/calloc,
-            // you MUST free it here to prevent a memory leak. If it returns a static pointer,
-            // remove this line.
-            std::free(svg_c_str);
-
+            
+            std::string svg{img2num::labels_to_svg(data_ptr, labels_ptr, width, height, min_area)};
+            pybind11::str svg_py_str(svg);
+            
             return svg_py_str;
         },
         pybind11::arg("data"), pybind11::arg("labels"), pybind11::arg("width"), pybind11::arg("height"),

--- a/bindings/py/src/img2num_pybind.cpp
+++ b/bindings/py/src/img2num_pybind.cpp
@@ -114,7 +114,7 @@ PYBIND11_MODULE(_img2num, m) {
             const int32_t* labels_ptr{static_cast<const int32_t*>(labels.request().ptr)};
             
             std::string svg{img2num::labels_to_svg(data_ptr, labels_ptr, width, height, min_area)};
-            pybind11::str svg_py_str(svg);
+            pybind11::str svg_py_str(std::move(svg));
             
             return svg_py_str;
         },

--- a/core/include/img2num.h
+++ b/core/include/img2num.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 /// @note All image buffers are assumed to be stored in row-major order, unless otherwise noted.
 namespace img2num {
@@ -37,7 +38,7 @@ void bilateral_filter(uint8_t *image, size_t width, size_t height, double sigma_
                       double sigma_range, uint8_t color_space);
 
 /// @copydoc IMG2NUM_H_LABELS_TO_SVG_DOC
-char *labels_to_svg(const uint8_t *data, const int32_t *labels, const int width, const int height,
+std::string labels_to_svg(const uint8_t *data, const int32_t *labels, const int width, const int height,
                     const int min_area);
 }  // namespace img2num
 

--- a/core/src/internal/labels_to_svg.cpp
+++ b/core/src/internal/labels_to_svg.cpp
@@ -245,8 +245,6 @@ std::string labels_to_svg(const uint8_t *data, const int32_t *labels, const int 
     }
 
     // 7. Return SVG
-    std::string svg{contoursResultToSVG(all_contours, width, height)};
-
-    return svg;
+    return contoursResultToSVG(all_contours, width, height);
 }
 }  // namespace img2num

--- a/core/src/internal/labels_to_svg.cpp
+++ b/core/src/internal/labels_to_svg.cpp
@@ -186,7 +186,7 @@ format ([r,g,b,a, r,g,b,a, ...]) labels: int32_t* -> output of labelled regions
 from K-Means, should be 1/4 the size of data since data is RGBA labels : width *
 height : number of pixels in image = 1 : 1 : 1
 */
-char *labels_to_svg(const uint8_t *data, const int32_t *labels, const int width, const int height,
+std::string labels_to_svg(const uint8_t *data, const int32_t *labels, const int width, const int height,
                     const int min_area) {
     const int32_t num_pixels{width * height};
     std::vector<int32_t> labels_vector{labels, labels + num_pixels};
@@ -247,13 +247,6 @@ char *labels_to_svg(const uint8_t *data, const int32_t *labels, const int width,
     // 7. Return SVG
     std::string svg{contoursResultToSVG(all_contours, width, height)};
 
-    // Dynamic C-style allocation (since returned over C ABI)
-    char *res_svg{static_cast<char *>(std::malloc(svg.size() + 1))};
-    if (!res_svg) {
-        return nullptr;  // Allocation failed
-    }
-    std::memcpy(res_svg, svg.c_str(), svg.size() + 1);
-
-    return res_svg;
+    return svg;
 }
 }  // namespace img2num

--- a/doxygen/img2num.h.dox
+++ b/doxygen/img2num.h.dox
@@ -84,7 +84,6 @@
 /// @param width Width of the image in pixels.
 /// @param height Height of the image in pixels.
 /// @param min_area Minimum area (in pixels) for a region to be included in the SVG.
-/// @return Pointer to a dynamically allocated C-string containing the SVG data.
-/// @note Caller is responsible for freeing the returned string.
+/// @return std::string A valid SVG string containing the data.
 /// @note Dox File: `doxygen/img2num.h.dox`
 ///

--- a/example-apps/console-cpp/main.cpp
+++ b/example-apps/console-cpp/main.cpp
@@ -62,15 +62,7 @@ int main(int argc, char** argv) {
     // Apply kmeans
     img2num::kmeans(img_data, out_data, out_labels, width, height, 32, 100, 1);
     // Generate SVG
-    char* res_svg{img2num::labels_to_svg(img_data, out_labels, width, height, 100)};
-    if (!res_svg) {
-        std::cerr << "Failed to generate SVG: allocation failed" << std::endl;
-        stbi_image_free(image_data_original);
-        delete[] img_data;
-        delete[] out_data;
-        delete[] out_labels;
-        return 1;
-    }
+    std::string res_svg{img2num::labels_to_svg(img_data, out_labels, width, height, 100)};
 
     // Save the blurred image
     std::string out_path{std::string(OUT_DIR) + "/console-cpp-output.png"};
@@ -102,7 +94,5 @@ int main(int argc, char** argv) {
     delete[] img_data;
     delete[] out_data;
     delete[] out_labels;
-    std::free(res_svg);
-    res_svg = nullptr;
     return exit_code;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->



## What was changed & why

In `core` img2num label_to_svg will return `std::string` as it manages it's own deallocation, thus making it easier for users to not have to manage `malloc` and `free` on their own.
For c and js bindings, `cimg2num` will convert std::string to char*. Most users should default to img2num instead of cimg2num.

Fixes: #265 - no deallocation function as you now just call `free(svg)` from C
Fixes: #266

## Changes

<!-- A list of important changes -->

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the `labels_to_svg` function to use modern C++ string types instead of C-style character pointers, providing improved consistency across all language bindings and core implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->