### PR TITLE
feat(devcontainer): add GitHub Codespaces config using the published dev image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "Img2Num Dev",
+  "image": "ryanmillard/img2num-dev:latest",
+  "workspaceFolder": "/usr/src/app",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/usr/src/app,type=bind,consistency=cached",
+  "forwardPorts": [3000, 4173, 5173],
+  "portsAttributes": {
+    "3000": { "label": "Docusaurus dev", "onAutoForward": "notify" },
+    "4173": { "label": "Vite preview", "onAutoForward": "silent" },
+    "5173": { "label": "Vite dev", "onAutoForward": "openPreview" }
+  },
+  "containerEnv": {
+    "CHOKIDAR_USEPOLLING": "true",
+    "CHOKIDAR_INTERVAL": "100",
+    "npm_config_store_dir": "/pnpm/store"
+  },
+  "mounts": [
+    "source=img2num-pnpm-store,target=/pnpm,type=volume"
+  ],
+  "postCreateCommand": "pnpm install --no-frozen-lockfile",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "EditorConfig.EditorConfig",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake",
+        "ms-python.python",
+        "redhat.vscode-yaml",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   "mounts": [
     "source=img2num-pnpm-store,target=/pnpm,type=volume"
   ],
-  "postCreateCommand": "pnpm install --no-frozen-lockfile",
+  "postCreateCommand": "pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Deploy to GitHub Pages](https://github.com/Ryan-Millard/Img2Num/actions/workflows/deploy.yml/badge.svg)](https://github.com/Ryan-Millard/Img2Num/actions/workflows/deploy.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Ryan-Millard/Img2Num/blob/main/LICENSE)
 [![Docker Pulls](https://img.shields.io/docker/pulls/ryanmillard/img2num-dev)](https://hub.docker.com/repository/docker/ryanmillard/img2num-dev/general)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Ryan-Millard/Img2Num)
+[![Open in Codespaces](https://img.shields.io/badge/-Open%20in%20Codespaces-black?logo=github)](https://codespaces.new/Ryan-Millard/Img2Num)
 
 <a href="https://skillicons.dev">
   <img height="25px" src="https://skillicons.dev/icons?i=cpp,c,js" />

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Deploy to GitHub Pages](https://github.com/Ryan-Millard/Img2Num/actions/workflows/deploy.yml/badge.svg)](https://github.com/Ryan-Millard/Img2Num/actions/workflows/deploy.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Ryan-Millard/Img2Num/blob/main/LICENSE)
 [![Docker Pulls](https://img.shields.io/docker/pulls/ryanmillard/img2num-dev)](https://hub.docker.com/repository/docker/ryanmillard/img2num-dev/general)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Ryan-Millard/Img2Num)
 
 <a href="https://skillicons.dev">
   <img height="25px" src="https://skillicons.dev/icons?i=cpp,c,js" />


### PR DESCRIPTION
## Summary

Adds `.devcontainer/devcontainer.json` so contributors can spin up a working Img2Num environment in GitHub Codespaces with one click. Uses the published `ryanmillard/img2num-dev:latest` image (same image `docker-compose.yml` already references), forwards the dev/preview ports, and preinstalls a sensible set of VS Code extensions for the C++/JS stack.

Also adds an "Open in GitHub Codespaces" badge to the README so the entry point is discoverable from the repo landing page.

Closes #293

## What's in the devcontainer.json

- `image: ryanmillard/img2num-dev:latest` — reuses the published image, so cold-starts skip the Dockerfile.dev build entirely.
- Workspace mount at `/usr/src/app` matching `docker-compose.yml`.
- Forwarded ports: `3000` (Docusaurus dev), `5173` (Vite dev, opens preview), `4173` (Vite preview, silent).
- `npm_config_store_dir=/pnpm/store` paired with a `img2num-pnpm-store` named volume so pnpm caches survive Codespace rebuilds.
- `postCreateCommand: pnpm install --no-frozen-lockfile` to refresh dependencies on first attach.
- VS Code extensions: ESLint, Prettier, EditorConfig, C/C++ tools, CMake Tools, twxs.cmake, Python, YAML, Docker.

## Testing

- `python3 -c "import json; json.load(open('.devcontainer/devcontainer.json'))"` — JSON valid.
- `pnpm prettier --check .devcontainer/devcontainer.json README.md` — clean.
- The `image` field matches what `docker-compose.yml` pulls today, so a Codespaces session will get the same toolchain (Node 22, gcc-14, CMake, pybind11, uv, pnpm, doxygen) that Docker users already have.
- Did NOT modify `.devcontainer/entrypoint.sh` (leftover from an earlier setup attempt, unreferenced — felt out of scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preconfigured development container setup that provisions dependencies, developer tool extensions, and persistent caching automatically on creation.

* **Documentation**
  * Added a GitHub Codespaces badge to the README linking directly to the repository's cloud development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->