### PR TITLE
Potential fix for code scanning alert no. 81: Uncontrolled data used in path expression

### DIFF
--- a/core/tools/embed_shaders.py
+++ b/core/tools/embed_shaders.py
@@ -1,7 +1,20 @@
 import sys, pathlib
 
-SHADER_DIR = pathlib.Path(sys.argv[1])
-OUTPUT_FILE = pathlib.Path(sys.argv[2])
+def require_within_root(path: pathlib.Path, root: pathlib.Path, label: str) -> pathlib.Path:
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        raise ValueError(f"{label} must be within {root_resolved}: {resolved}")
+    return resolved
+
+ROOT_DIR = pathlib.Path.cwd().resolve()
+SHADER_DIR = require_within_root(pathlib.Path(sys.argv[1]), ROOT_DIR, "SHADER_DIR")
+OUTPUT_FILE = require_within_root(pathlib.Path(sys.argv[2]), ROOT_DIR, "OUTPUT_FILE")
+
+if not SHADER_DIR.is_dir():
+    raise ValueError(f"SHADER_DIR is not a directory: {SHADER_DIR}")
 
 # Must always appear in the same order for predictability
 files = sorted(SHADER_DIR.glob("*.wgsl"))

--- a/core/tools/embed_shaders.py
+++ b/core/tools/embed_shaders.py
@@ -1,8 +1,16 @@
 import sys, pathlib
 
 def require_within_root(path: pathlib.Path, root: pathlib.Path, label: str) -> pathlib.Path:
-    resolved = path.resolve()
-    root_resolved = root.resolve()
+    try:
+        root_resolved = root.resolve(strict=True)
+    except FileNotFoundError:
+        raise ValueError(f"Root path does not exist: {root}")
+
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError:
+        raise ValueError(f"{label} does not exist: {path}")
+
     try:
         resolved.relative_to(root_resolved)
     except ValueError:


### PR DESCRIPTION
Potential fix for [https://github.com/Ryan-Millard/Img2Num/security/code-scanning/81](https://github.com/Ryan-Millard/Img2Num/security/code-scanning/81)

Best fix: validate and constrain CLI-derived paths before file operations. For this script, the safest low-impact approach is to resolve paths and enforce that:
1. `SHADER_DIR` exists and is a directory.
2. `OUTPUT_FILE` resolves to a location inside the current working tree (or another explicit safe root), preventing arbitrary writes outside project scope.

In `core/tools/embed_shaders.py`, replace direct `Path(sys.argv[i])` assignments with resolved paths plus checks. Add a small helper `require_within_root(path, root, label)` that uses `Path.resolve()` and `relative_to()` to enforce containment. Then use validated `OUTPUT_FILE` for reads/writes as before. This preserves existing functionality for expected in-repo usage while preventing traversal/absolute-path abuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
