### PR TITLE
build(cmake): Restructure CMake configuration for component-level exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,36 +40,3 @@ else()
     add_subdirectory(example-apps/console-c)
   endif()
 endif()
-
-# --- Install export for package ---
-include(GNUInstallDirs)
-
-install(EXPORT Img2NumTargets
-  FILE Img2NumTargets.cmake
-  NAMESPACE Img2Num::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Img2Num
-)
-
-include(CMakePackageConfigHelpers)
-
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfigVersion.cmake"
-    VERSION 0.0.0
-    COMPATIBILITY SameMajorVersion
-)
-
-configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Img2NumConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Img2Num
-)
-
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfig.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Img2Num
-)
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/packages/py/img2num/
-    DESTINATION img2num
-    FILES_MATCHING PATTERN "*.py"
-)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -1,6 +1,14 @@
 # =================================================================
 # Img2Num C Bindings
 # =================================================================
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CIMG2NUM_VERSION 0.0.0)
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 # Wrapper source
 set(C_BINDINGS_SRC
     src/cimg2num.cpp
@@ -9,8 +17,13 @@ set(C_BINDINGS_SRC
 
 add_library(CImg2Num ${C_BINDINGS_SRC})
 
+set_target_properties(CImg2Num PROPERTIES
+  VERSION ${CIMG2NUM_VERSION}
+  SOVERSION 1
+)
+
 # Link against the core C++ library
-target_link_libraries(CImg2Num PRIVATE Img2Num)
+target_link_libraries(CImg2Num PUBLIC Img2Num)
 
 target_include_directories(CImg2Num
   PUBLIC
@@ -19,11 +32,35 @@ target_include_directories(CImg2Num
 )
 
 # Install headers and library
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/CImg2NumConfigVersion.cmake"
+  VERSION ${CIMG2NUM_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CImg2NumConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CImg2NumConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CImg2Num
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/CImg2NumConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/CImg2NumConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CImg2Num
+)
+
 install(TARGETS CImg2Num
-    EXPORT Img2NumTargets
-      LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
-      ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
-      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cimg2num
+  EXPORT CImg2NumTargets
+    LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cimg2num
+)
+
+install(EXPORT CImg2NumTargets
+  FILE CImg2NumTargets.cmake
+  NAMESPACE CImg2Num::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CImg2Num
 )
 
 install(DIRECTORY include/

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -4,7 +4,10 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CIMG2NUM_VERSION 0.0.0)
+project(CImg2Num
+  LANGUAGES CXX
+  VERSION 0.0.0
+)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -18,7 +21,7 @@ set(C_BINDINGS_SRC
 add_library(CImg2Num ${C_BINDINGS_SRC})
 
 set_target_properties(CImg2Num PROPERTIES
-  VERSION ${CIMG2NUM_VERSION}
+  VERSION ${PROJECT_VERSION}
   SOVERSION 1
 )
 
@@ -34,7 +37,7 @@ target_include_directories(CImg2Num
 # Install headers and library
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/CImg2NumConfigVersion.cmake"
-  VERSION ${CIMG2NUM_VERSION}
+  VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion
 )
 

--- a/bindings/c/cmake/CImg2NumConfig.cmake.in
+++ b/bindings/c/cmake/CImg2NumConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Img2Num REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/CImg2NumTargets.cmake")

--- a/bindings/py/CMakeLists.txt
+++ b/bindings/py/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 project(PyImg2Num LANGUAGES CXX)
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -17,6 +20,11 @@ target_link_libraries(_img2num PRIVATE Img2Num)
 
 target_include_directories(_img2num PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/packages/py/img2num/
+    DESTINATION img2num
+    FILES_MATCHING PATTERN "*.py"
 )
 
 install(TARGETS _img2num

--- a/bindings/py/CMakeLists.txt
+++ b/bindings/py/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.16)
-project(PyImg2Num LANGUAGES CXX)
+# =================================================================
+# Img2Num Python Bindings
+# =================================================================
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(PyImg2Num
+  LANGUAGES CXX
+  VERSION 0.0.0
+)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,11 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(IMG2NUM_VERSION 0.0.0)
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 file(GLOB_RECURSE CORE_SRC
   "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
 )
@@ -31,6 +36,11 @@ add_custom_target(Img2Num_shaders ALL
 )
 
 add_library(Img2Num ${CORE_SRC})
+
+set_target_properties(Img2Num PROPERTIES
+  VERSION ${IMG2NUM_VERSION}
+  SOVERSION 1
+)
 
 set_property(TARGET Img2Num PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -78,11 +88,35 @@ else()
 endif()
 
 # --- Install targets for packaging ---
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfigVersion.cmake"
+  VERSION ${IMG2NUM_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Img2NumConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Img2Num
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Img2Num
+)
+
 install(TARGETS Img2Num
   EXPORT Img2NumTargets
     LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/img2num
+)
+
+install(EXPORT Img2NumTargets
+  FILE Img2NumTargets.cmake
+  NAMESPACE Img2Num::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Img2Num
 )
 
 install(DIRECTORY include/

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,7 +4,10 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(IMG2NUM_VERSION 0.0.0)
+project(Img2Num
+  LANGUAGES CXX
+  VERSION 0.0.0
+)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -38,7 +41,7 @@ add_custom_target(Img2Num_shaders ALL
 add_library(Img2Num ${CORE_SRC})
 
 set_target_properties(Img2Num PROPERTIES
-  VERSION ${IMG2NUM_VERSION}
+  VERSION ${PROJECT_VERSION}
   SOVERSION 1
 )
 
@@ -90,7 +93,7 @@ endif()
 # --- Install targets for packaging ---
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/Img2NumConfigVersion.cmake"
-  VERSION ${IMG2NUM_VERSION}
+  VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion
 )
 

--- a/core/cmake/Img2NumConfig.cmake.in
+++ b/core/cmake/Img2NumConfig.cmake.in
@@ -1,3 +1,5 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
 include("${CMAKE_CURRENT_LIST_DIR}/Img2NumTargets.cmake")


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

<!-- A sentence or two describing the change. -->
<!-- A brief motivation for this change -->

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: none - prepares repository for #304 

## Changes

Move each CMake install to the corresponding CMakeLists.txt so it isn't monolithic and is simpler to manage as a monorepo.

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<details><summary>CMake Installation</summary>
<p>

```sh
ryan@Ryans-PC:~/projects/Img2Num$ ./img2num sh
[+] up 2/2
 ✔ Image ryanmillard/img2num-dev:latest Pulled                                                                                                                                          3.0s
 ✔ Container img2num-dev-1              Running                                                                                                                                         0.0s
root@8c5abede0223:/usr/src/app# rm -rf build
cmake -B build -DCMAKE_INSTALL_PREFIX=./install
cmake --build build
cmake --install build
-- The CXX compiler identification is GNU 14.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++-14 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMAKE_BUILD_TYPE unspecified - defaulting to "Release"
-- Build type: Release
-- /usr/src/app/build
-- Found Python3: /usr/bin/python3 (found version "3.13.5") found components: Interpreter
Found system Dawn
-- Core library configured with /usr/src/app/core/src/img2num/Error.cpp;/usr/src/app/core/src/internal/SavitskyGolay.cpp;/usr/src/app/core/src/internal/bezier.cpp;/usr/src/app/core/src/internal/bilateral_filter.cpp;/usr/src/app/core/src/internal/bilateral_filter_gpu.cpp;/usr/src/app/core/src/internal/contours.cpp;/usr/src/app/core/src/internal/fft_iterative.cpp;/usr/src/app/core/src/internal/graph.cpp;/usr/src/app/core/src/internal/image_utils.cpp;/usr/src/app/core/src/internal/kmeans.cpp;/usr/src/app/core/src/internal/kmeans_gpu.cpp;/usr/src/app/core/src/internal/labels_to_svg.cpp;/usr/src/app/core/src/internal/node.cpp
-- C bindings library configured with src/cimg2num.cpp;src/cimg2num/img2num_error_t.cpp
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc-14 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done (0.7s)
-- Generating done (0.0s)
-- Build files have been written to: /usr/src/app/build
Writing to /usr/src/app/build/embedded_shaders.h
[  0%] Built target Img2Num_shaders
[  4%] Building CXX object core/CMakeFiles/Img2Num.dir/src/img2num/Error.cpp.o
[  9%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/SavitskyGolay.cpp.o
[ 14%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/bezier.cpp.o
[ 19%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/bilateral_filter.cpp.o
[ 23%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/bilateral_filter_gpu.cpp.o
[ 28%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/contours.cpp.o
[ 33%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/fft_iterative.cpp.o
[ 38%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/graph.cpp.o
[ 42%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/image_utils.cpp.o
[ 47%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/kmeans.cpp.o
[ 52%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/kmeans_gpu.cpp.o
[ 57%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/labels_to_svg.cpp.o
[ 61%] Building CXX object core/CMakeFiles/Img2Num.dir/src/internal/node.cpp.o
[ 66%] Linking CXX static library libImg2Num.a
[ 66%] Built target Img2Num
[ 71%] Building CXX object bindings/c/CMakeFiles/CImg2Num.dir/src/cimg2num.cpp.o
[ 76%] Building CXX object bindings/c/CMakeFiles/CImg2Num.dir/src/cimg2num/img2num_error_t.cpp.o
[ 80%] Linking CXX static library libCImg2Num.a
[ 80%] Built target CImg2Num
[ 85%] Building CXX object example-apps/console-cpp/CMakeFiles/console_cpp_app.dir/main.cpp.o
[ 90%] Linking CXX executable console_cpp_app
[ 90%] Built target console_cpp_app
[ 95%] Building C object example-apps/console-c/CMakeFiles/console_c_app.dir/main.c.o
[100%] Linking CXX executable console_c_app
[100%] Built target console_c_app
-- Install configuration: "Release"
-- Installing: /usr/src/app/install/lib/cmake/Img2Num/Img2NumConfig.cmake
-- Installing: /usr/src/app/install/lib/cmake/Img2Num/Img2NumConfigVersion.cmake
-- Installing: /usr/src/app/install/lib/libImg2Num.a
-- Installing: /usr/src/app/install/lib/cmake/Img2Num/Img2NumTargets.cmake
-- Installing: /usr/src/app/install/lib/cmake/Img2Num/Img2NumTargets-release.cmake
-- Up-to-date: /usr/src/app/install/include/img2num
-- Up-to-date: /usr/src/app/install/include/img2num/img2num.h
-- Up-to-date: /usr/src/app/install/include/img2num/internal
-- Up-to-date: /usr/src/app/install/include/img2num/img2num
-- Up-to-date: /usr/src/app/install/include/img2num/img2num/Error.h
-- Installing: /usr/src/app/install/lib/cmake/CImg2Num/CImg2NumConfig.cmake
-- Installing: /usr/src/app/install/lib/cmake/CImg2Num/CImg2NumConfigVersion.cmake
-- Installing: /usr/src/app/install/lib/libCImg2Num.a
-- Installing: /usr/src/app/install/lib/cmake/CImg2Num/CImg2NumTargets.cmake
-- Installing: /usr/src/app/install/lib/cmake/CImg2Num/CImg2NumTargets-release.cmake
-- Up-to-date: /usr/src/app/install/include/cimg2num
-- Up-to-date: /usr/src/app/install/include/cimg2num/cimg2num
-- Up-to-date: /usr/src/app/install/include/cimg2num/cimg2num/img2num_error_t.h
-- Up-to-date: /usr/src/app/install/include/cimg2num/cimg2num.h
root@8c5abede0223:/usr/src/app#
exit
ryan@Ryans-PC:~/projects/Img2Num$ tree install/
install/
├── include
│   ├── cimg2num
│   │   ├── cimg2num
│   │   │   └── img2num_error_t.h
│   │   └── cimg2num.h
│   └── img2num
│       ├── img2num
│       │   └── Error.h
│       ├── img2num.h
│       └── internal
└── lib
    ├── cmake
    │   ├── CImg2Num
    │   │   ├── CImg2NumConfig.cmake
    │   │   ├── CImg2NumConfigVersion.cmake
    │   │   ├── CImg2NumTargets-release.cmake
    │   │   └── CImg2NumTargets.cmake
    │   └── Img2Num
    │       ├── Img2NumConfig.cmake
    │       ├── Img2NumConfigVersion.cmake
    │       ├── Img2NumTargets-release.cmake
    │       └── Img2NumTargets.cmake
    ├── libCImg2Num.a
    └── libImg2Num.a

11 directories, 14 files
ryan@Ryans-PC:~/projects/Img2Num$
```

</p>
</details> 
