### PR TITLE
fix(docker): copy stb submodule into dev image to fix Python bindings

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -59,6 +59,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # After installing deps since Dawn is likely to change, not its deps
 COPY third_party/dawn third_party/dawn
+COPY third_party/stb third_party/stb
 
 RUN cmake -S third_party/dawn -B build/dawn \
     -DDAWN_SUPPORTS_GLFW_FOR_WINDOWING=OFF \


### PR DESCRIPTION
## Summary

The dev Docker image was missing the `stb` submodule, causing the Python
bindings build to fail with:

fatal error: stb/stb_image.h: No such file or directory

This meant that running `uv sync --no-build-isolation` inside the container
would always error out, blocking any contributor from setting up the Python
bindings locally.

## Root Cause

`Dockerfile.dev` copied `third_party/dawn` into the image, but never copied
`third_party/stb`. Since the Python bindings built via CMake depend on STB
for image loading, the build failed at compile time.

Note: Running `git submodule update --init --recursive` is not a viable
workaround because Dawn's nested sub-submodules include a Google-internal
repository (`chrome-internal.googlesource.com`) that requires special
credentials inaccessible to external contributors.

## Fix

Added `COPY third_party/stb third_party/stb` to `Dockerfile.dev`, alongside
the existing Dawn copy. Contributors must have the `stb` submodule initialized
on their host machine before building the image:

git submodule update --init third_party/stb

## Testing

Verified the full setup sequence inside the container succeeds:

uv venv
uv pip install scikit_build_core numpy
uv sync --no-build-isolation
uv run python3 -c "import img2num;"

All steps completed without errors.

## Related

Raised by @Ryan-Millard in issue #332 thread. This should close the #340 issue created by @coderabbitai in the thread.