### PR TITLE
docs: add a warning to Setup & Dependencies docs about Git submodules

### DIFF
--- a/docs/blog/2026-05-02-maintainers-expansion/index.md
+++ b/docs/blog/2026-05-02-maintainers-expansion/index.md
@@ -32,7 +32,7 @@ We're looking for experienced contributors ready to take on scoped, ongoing resp
 
 Img2Num is a layered system. Here's how the pieces fit together:
 
-````mermaid
+```mermaid
 flowchart TD
     A["core/<br/>(C++ Library)"] --> B["bindings/c/<br/>(C ABI Library)"]
     A --> C["bindings/py/<br/>(Python - pybind11)"]
@@ -53,56 +53,64 @@ flowchart TD
     class A core;
     class B,D,F layer;
     class C,E intermediary;
-````
+```
 
-| Layer | Path | Notes |
-|---|---|---|
-| C++ Core | `core/` | Source of truth for all algorithms |
-| C ABI | `bindings/c/` | Stable ABI boundary; feeds the Wasm pipeline |
-| WebAssembly | `bindings/js/` | Built via Emscripten from the C ABI |
-| JavaScript package | `packages/js/` | Safe runtime wrapper over the Wasm module |
-| Python bindings | `bindings/py/` | pybind11 directly on the C++ core |
-| Python package | `packages/py/` | Exposes the native Python module |
+| Layer              | Path           | Notes                                        |
+| ------------------ | -------------- | -------------------------------------------- |
+| C++ Core           | `core/`        | Source of truth for all algorithms           |
+| C ABI              | `bindings/c/`  | Stable ABI boundary; feeds the Wasm pipeline |
+| WebAssembly        | `bindings/js/` | Built via Emscripten from the C ABI          |
+| JavaScript package | `packages/js/` | Safe runtime wrapper over the Wasm module    |
+| Python bindings    | `bindings/py/` | pybind11 directly on the C++ core            |
+| Python package     | `packages/py/` | Exposes the native Python module             |
 
 ## Open Maintainer Areas
 
 ### CI/CD
+
 - GitHub Actions workflows, Docker builds, release pipelines, automated publishing.
 
 ### C ABI (`bindings/c`)
+
 - Maintain the C ABI over the C++ core. Must stay compatible with external C consumers and the Wasm pipeline.
 
 ### JavaScript / WebAssembly (`bindings/js`, `packages/js`)
+
 - Emscripten integration, browser and Node.js compatibility, pnpm workspace tooling, React example app.
 
 ### Python (`bindings/py`, `packages/py`)
+
 - pybind11 bindings, uv workspace tooling, console example app.
 
 ### Docs & DX (`docs/`, `doxygen/`)
+
 - Docusaurus site, Doxygen integration, tutorials, onboarding experience.
 
 ### Releases & Packaging
+
 - Versioning, tagging, GitHub Releases, npm and Docker Hub publishing.
 
 ### Testing & Validation
+
 - CI test coverage, linting/formatting enforcement, regression testing.
 
 ### Internal Tooling (`scripts/`)
+
 - Cross-platform CLI utilities, developer automation, local workflow improvements.
 
 ## Maintainer Tiers
 
-````mermaid
+```mermaid
 flowchart LR
     A[Junior Maintainer<br/>PR review & learning] --> B[Scoped Maintainer<br/>Domain ownership]
     B --> C[Core Maintainer<br/>Architecture & final decisions]
-````
+```
 
-| Tier | Merge Access | Responsibilities |
-|---|---|---|
-| **Junior** | None | Review small PRs, contribute within a defined scope |
-| **Scoped** | Within their domain | Own a specific area — review, approve, maintain quality |
-| **Core** | Broad | Cross-domain architecture, final merge authority, long-term direction |
+| Tier       | Merge Access        | Responsibilities                                                      |
+| ---------- | ------------------- | --------------------------------------------------------------------- |
+| **Junior** | None                | Review small PRs, contribute within a defined scope                   |
+| **Scoped** | Within their domain | Own a specific area — review, approve, maintain quality               |
+| **Core**   | Broad               | Cross-domain architecture, final merge authority, long-term direction |
 
 Trust is earned through consistent contributions. Everyone starts scoped.
 

--- a/docs/docs/contributing/setup-and-dependencies/index.md
+++ b/docs/docs/contributing/setup-and-dependencies/index.md
@@ -36,6 +36,19 @@ git clone --recursive https://github.com/Ryan-Millard/Img2Num.git
 cd Img2Num/
 ```
 
+:::warning Cloning without `--recursive`
+If you cloned the repository without the `--recursive` flag, the `third_party/stb`
+submodule will be missing and you will see a build error like:
+
+fatal error: stb/stb_image.h: No such file or directory
+
+To fix this, run the following from the project root:
+
+```bash
+git submodule update --init third_party/stb
+```
+:::
+
 ## Docker
 
 ### Start Docker

--- a/docs/docs/contributing/setup-and-dependencies/index.md
+++ b/docs/docs/contributing/setup-and-dependencies/index.md
@@ -36,17 +36,51 @@ git clone --recursive https://github.com/Ryan-Millard/Img2Num.git
 cd Img2Num/
 ```
 
-:::warning Cloning without `--recursive`
-If you cloned the repository without the `--recursive` flag, the `third_party/stb`
-submodule will be missing and you will see a build error like:
+:::warning[Missing submodules after cloning]
 
-fatal error: stb/stb_image.h: No such file or directory
+<details className="alert--warning">
+<summary>
 
-To fix this, run the following from the project root:
+If you cloned without `--recursive`, required dependencies will be missing.
+
+</summary>
+
+<Tabs>
+  <TabItem value="all" label="All (optional)" default>
+
+This clones all submodules:
+- `stb` (required)
+- `dawn` (optional, required for local native builds)
+
+```bash
+git submodule update --init third_party
+````
+
+  </TabItem>
+
+  <TabItem value="stb" label="STB (required)" default>
+
+`stb` is always required.
 
 ```bash
 git submodule update --init third_party/stb
+````
+
+  </TabItem>
+
+  <TabItem value="dawn" label="Dawn (optional)">
+
+Only needed for local native builds. The `img2num-dev` Docker image already has it built.
+
+```bash
+git submodule update --init third_party/dawn
 ```
+
+  </TabItem>
+</Tabs>
+
+</details>
+
 :::
 
 ## Docker

--- a/docs/docs/contributing/setup-and-dependencies/index.md
+++ b/docs/docs/contributing/setup-and-dependencies/index.md
@@ -49,12 +49,13 @@ If you cloned without `--recursive`, required dependencies will be missing.
   <TabItem value="all" label="All (optional)" default>
 
 This clones all submodules:
+
 - `stb` (required)
 - `dawn` (optional, required for local native builds)
 
 ```bash
 git submodule update --init third_party
-````
+```
 
   </TabItem>
 
@@ -64,7 +65,7 @@ git submodule update --init third_party
 
 ```bash
 git submodule update --init third_party/stb
-````
+```
 
   </TabItem>
 


### PR DESCRIPTION
Closes #343

## Summary

Adds a warning admonition to the Setup & Dependencies documentation for contributors who clone the repository without the `--recursive` flag, leaving the `third_party/stb` submodule uninitialised.

## Problem

When cloning without `--recursive`, `third_party/stb` is an empty directory on the host machine. Since the Docker dev container mounts the project directory, it sees the same empty folder, causing the Python bindings build to fail with:

```
fatal error: stb/stb_image.h: No such file or directory
```

This was discovered during setup in #341 (now reopened as another issue). The clone command in the docs already includes `--recursive`, but there was no guidance for contributors who had already cloned without it.

## Fix

Added a `:::warning` admonition block directly beneath the clone command in `docs/docs/contributing/setup-and-dependencies/index.md` explaining the symptom and the recovery command:

```bash
git submodule update --init third_party/stb
```

## Related

- Closes #343
- Requested by @Ryan-Millard in the #341 thread
