### PR TITLE
chore(packages/js): explicitly include on the required build-wasm files

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -28,7 +28,8 @@
     "node": ">=14"
   },
   "files": [
-    "build-wasm/",
+    "build-wasm/index.js",
+    "build-wasm/index.wasm",
     "index.js",
     "safeWasmWrappers.js",
     "wasmClient.js",


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

`files` section in `packages/js/package.json`.

This avoids packaging unnecessary and large files.

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: none

## Changes

One file

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->
