### PR TITLE
fix(ci): fix broken releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,3 @@
-# ==================================================================
-# Required repository secrets / environment variables (not built-in)
-# ==================================================================
-# Custom secrets (must be configured in repo settings):
-#
-# - RELEASE_PROPAGATION_TOKEN
-#   Used in propagation jobs (propagate-cpp, propagate-c) to:
-#   - push branches
-#   - create pull requests via GitHub CLI (gh pr create)
-#   Requires repo write + PR permissions.
-#
-# Notes:
-# - All release-please outputs (tags/versions) are derived from:
-#   .release-please-manifest.json + release-please-config.json
-# - No GHCR token is required; registry uses GITHUB_TOKEN implicitly.
-# ============================================================
-#
 name: Release (release-please, multi-language assets)
 
 on:
@@ -165,6 +148,8 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public --provenance
         working-directory: packages/js
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Wheels + PyPI (Python)
   build-py:

--- a/.prettierignore
+++ b/.prettierignore
@@ -43,3 +43,4 @@ bindings/py/
 bindings/c/
 packages/py
 docs/static/
+**/CHANGELOG.md

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "core": "0.1.0",
   "bindings/c": "0.1.0",
-  "packages/js": "0.0.0",
+  "packages/js": "0.1.0",
   "packages/py": "0.1.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "core": "0.1.0",
-  "bindings/c": "0.0.0",
+  "bindings/c": "0.1.0",
   "packages/js": "0.0.0",
   "packages/py": "0.0.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,5 @@
   "core": "0.1.0",
   "bindings/c": "0.1.0",
   "packages/js": "0.0.0",
-  "packages/py": "0.0.0"
+  "packages/py": "0.1.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "core": "0.0.0",
+  "core": "0.1.0",
   "bindings/c": "0.0.0",
   "packages/js": "0.0.0",
   "packages/py": "0.0.0"

--- a/bindings/c/CHANGELOG.md
+++ b/bindings/c/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 0.1.0 (2026-05-29)
+
+
+### ⚠ BREAKING CHANGES
+
+* **core:** img2num::labels_to_svg now returns std::string instead of char*. Callers using the C++ API must update their code to capture the return value as std::string and remove any associated std::free / delete[] calls. Callers using the C binding (cimg2num) are unaffected at the ABI level but should use img2num_free_svg to deallocate the returned buffer.
+* **api:** remove draw_contour_borders from labels_to_svg ([#283](https://github.com/Ryan-Millard/Img2Num/issues/283))
+
+### ✨ Features
+
+* **library, bindings, examples:** C bindings, C & C++ shared libs, C & C++ example apps ([#263](https://github.com/Ryan-Millard/Img2Num/issues/263)) ([bb2403e](https://github.com/Ryan-Millard/Img2Num/commit/bb2403ee1a9a81f39d2b5a1746c404c3c526a2f3))
+* unified image_to_svg function as complete pipeline ([#335](https://github.com/Ryan-Millard/Img2Num/issues/335)) ([bdba68c](https://github.com/Ryan-Millard/Img2Num/commit/bdba68c8adbbf79a163aba9df25849c5ff36a6b9))
+
+
+### ♻️ Refactoring
+
+* **api:** remove draw_contour_borders from labels_to_svg ([#283](https://github.com/Ryan-Millard/Img2Num/issues/283)) ([eee9b31](https://github.com/Ryan-Millard/Img2Num/commit/eee9b3135b5b651a20cc8ffab74bcef073b74b6a))
+* **core:** update labels_to_svg to return std::string ([#333](https://github.com/Ryan-Millard/Img2Num/issues/333)) ([a71e3b1](https://github.com/Ryan-Millard/Img2Num/commit/a71e3b17505306b96ebe56439b1f78215e53e56d))

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(CImg2Num
   LANGUAGES CXX
   # Don't change the inline comment below - release-please needs it
-  VERSION 0.0.0 # x-release-please-version
+  VERSION 0.1.0 # x-release-please-version
 )
 
 include(CMakePackageConfigHelpers)

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 0.1.0 (2026-05-29)
+
+
+### ⚠ BREAKING CHANGES
+
+* **core:** img2num::labels_to_svg now returns std::string instead of char*. Callers using the C++ API must update their code to capture the return value as std::string and remove any associated std::free / delete[] calls. Callers using the C binding (cimg2num) are unaffected at the ABI level but should use img2num_free_svg to deallocate the returned buffer.
+* **api:** remove draw_contour_borders from labels_to_svg ([#283](https://github.com/Ryan-Millard/Img2Num/issues/283))
+
+### ✨ Features
+
+* **example-app:** (React) add GlassModal and upgrade Editor page (saving, histories, fullscreen, bug fixes) ([#278](https://github.com/Ryan-Millard/Img2Num/issues/278)) ([d46a4c9](https://github.com/Ryan-Millard/Img2Num/commit/d46a4c96a8153854a4c298a93e873bb8f81a2fb5))
+* **library, bindings, examples:** C bindings, C & C++ shared libs, C & C++ example apps ([#263](https://github.com/Ryan-Millard/Img2Num/issues/263)) ([bb2403e](https://github.com/Ryan-Millard/Img2Num/commit/bb2403ee1a9a81f39d2b5a1746c404c3c526a2f3))
+* **python:** enable Python bindings via pybind11 and add console-py example ([#307](https://github.com/Ryan-Millard/Img2Num/issues/307)) ([294ae53](https://github.com/Ryan-Millard/Img2Num/commit/294ae53f4967495ff73c9c391bafc2e115a7eccf))
+* unified image_to_svg function as complete pipeline ([#335](https://github.com/Ryan-Millard/Img2Num/issues/335)) ([bdba68c](https://github.com/Ryan-Millard/Img2Num/commit/bdba68c8adbbf79a163aba9df25849c5ff36a6b9))
+
+
+### 🐛 Bug Fixes
+
+* **gpu:** handle fallback when no GPU is available ([#286](https://github.com/Ryan-Millard/Img2Num/issues/286)) ([3d312ff](https://github.com/Ryan-Millard/Img2Num/commit/3d312ffcecc8e026845dbd5603a17b152c7b42a3))
+* **graph-memory-leak:** fix memory leak caused by shared_ptr(s) ([#295](https://github.com/Ryan-Millard/Img2Num/issues/295)) ([33605a5](https://github.com/Ryan-Millard/Img2Num/commit/33605a59bb01b6b5f0b794af850c2ae35fbfa563))
+* **webgpu:** increase buffer limit beyond 256MB ([#302](https://github.com/Ryan-Millard/Img2Num/issues/302)) ([fe3cf5a](https://github.com/Ryan-Millard/Img2Num/commit/fe3cf5a48ddd4742d31334da38c0e46db444833d))
+
+
+### ⚡ Performance Improvements
+
+* **gpu:** add WebGPU acceleration with automatic fallback to CPU ([#272](https://github.com/Ryan-Millard/Img2Num/issues/272)) ([c385319](https://github.com/Ryan-Millard/Img2Num/commit/c3853198aaf72e00888352653bf44fe129261201))
+* optimize graph functions to reduce processing time ~2x ([#290](https://github.com/Ryan-Millard/Img2Num/issues/290)) ([0f372bb](https://github.com/Ryan-Millard/Img2Num/commit/0f372bbbd218a25680e6b8a45590f85756d5af97))
+
+
+### ♻️ Refactoring
+
+* **api:** remove draw_contour_borders from labels_to_svg ([#283](https://github.com/Ryan-Millard/Img2Num/issues/283)) ([eee9b31](https://github.com/Ryan-Millard/Img2Num/commit/eee9b3135b5b651a20cc8ffab74bcef073b74b6a))
+* **core:** update labels_to_svg to return std::string ([#333](https://github.com/Ryan-Millard/Img2Num/issues/333)) ([a71e3b1](https://github.com/Ryan-Millard/Img2Num/commit/a71e3b17505306b96ebe56439b1f78215e53e56d))

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(Img2Num
   LANGUAGES CXX
   # Don't change the inline comment below - release-please needs it
-  VERSION 0.0.0 # x-release-please-version
+  VERSION 0.1.0 # x-release-please-version
 )
 
 include(CMakePackageConfigHelpers)

--- a/core/include/internal/LABAPixel.h
+++ b/core/include/internal/LABAPixel.h
@@ -4,6 +4,10 @@
 #include "internal/LABPixel.h"
 
 namespace ImageLib {
+
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 template <typename NumberT>
 struct LABAPixel : public ImageLib::LABPixel<NumberT> {
     // ----- Members -----
@@ -28,7 +32,14 @@ struct LABAPixel : public ImageLib::LABPixel<NumberT> {
         this->alpha = alpha;
     }
 
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 template <typename NumberT>
 std::ostream &operator<<(std::ostream &out, const ImageLib::LABAPixel<NumberT> &pixel) {

--- a/core/include/internal/LABPixel.h
+++ b/core/include/internal/LABPixel.h
@@ -12,6 +12,10 @@ preferrably float or double
 */
 
 namespace ImageLib {
+
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 template <typename NumberT>
 struct LABPixel : public Pixel<NumberT> {
     // ----- Members -----
@@ -43,7 +47,14 @@ struct LABPixel : public Pixel<NumberT> {
                          (a.b - b.b) * (a.b - b.b));
     }
 
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 template <typename NumberT>
 std::ostream &operator<<(std::ostream &out, const ImageLib::LABPixel<NumberT> &pixel) {

--- a/core/include/internal/RGBAPixel.h
+++ b/core/include/internal/RGBAPixel.h
@@ -4,6 +4,10 @@
 #include "internal/RGBPixel.h"
 
 namespace ImageLib {
+
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 template <typename NumberT>
 struct RGBAPixel : public ImageLib::RGBPixel<NumberT> {
     // ----- Members -----
@@ -28,7 +32,14 @@ struct RGBAPixel : public ImageLib::RGBPixel<NumberT> {
         this->alpha = alpha;
     }
 
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 template <typename NumberT>
 std::ostream &operator<<(std::ostream &out, const ImageLib::RGBAPixel<NumberT> &pixel) {

--- a/core/include/internal/RGBPixel.h
+++ b/core/include/internal/RGBPixel.h
@@ -7,6 +7,10 @@
 #include "internal/Pixel.h"
 
 namespace ImageLib {
+
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 template <typename NumberT>
 struct RGBPixel : public Pixel<NumberT> {
     // ----- Members -----
@@ -39,7 +43,14 @@ struct RGBPixel : public Pixel<NumberT> {
                          (af.blue - bf.blue) * (af.blue - bf.blue));
     }
 
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 template <typename NumberT>
 std::ostream &operator<<(std::ostream &out, const ImageLib::RGBPixel<NumberT> &pixel) {

--- a/core/src/internal/bilateral_filter_gpu.cpp
+++ b/core/src/internal/bilateral_filter_gpu.cpp
@@ -17,6 +17,9 @@ static constexpr uint8_t COLOR_SPACE_OPTION_CIELAB{0};
 static constexpr uint8_t COLOR_SPACE_OPTION_RGB{1};
 
 // Structure matching the WGSL Uniform (std140 layout)
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 struct FilterParams {
     float sigmaSpatial;
     float sigmaRange;
@@ -26,7 +29,14 @@ struct FilterParams {
     // However, it is safer to pad to 16 bytes to be sure.
     float _pad1;
     float _pad2;
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 void bilateral_filter_gpu(uint8_t* image, size_t width, size_t height, double sigma_spatial,
                           double sigma_range, uint8_t color_space) {

--- a/core/src/internal/contours.cpp
+++ b/core/src/internal/contours.cpp
@@ -7,6 +7,11 @@
 #include <set>
 #include <utility>
 
+// M_PI is not defined by default on MSVC
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 namespace contours {
 
 // 8-neighborhood, clockwise order starting from "right" (dx=+1,dy=0).

--- a/core/src/internal/image_utils.cpp
+++ b/core/src/internal/image_utils.cpp
@@ -13,6 +13,11 @@
 #include "internal/RGBAPixel.h"
 #include "internal/fft_iterative.h"
 
+// M_PI is not defined by default on MSVC
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 uint8_t quantize(uint8_t value, uint8_t region_size) {
     if (region_size == 0) {
         return value;

--- a/core/src/internal/kmeans_gpu.cpp
+++ b/core/src/internal/kmeans_gpu.cpp
@@ -26,24 +26,54 @@
 static constexpr uint8_t COLOR_SPACE_OPTION_CIELAB{0};
 static constexpr uint8_t COLOR_SPACE_OPTION_RGB{1};
 
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 struct Params {
     uint32_t numPoints;
     uint32_t numCentroids;
     uint32_t pad[2];
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 struct ClusterAccumulator {
     int32_t sumR;
     int32_t sumG;
     int32_t sumB;
     uint32_t count;
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 struct CentroidParams {
     float r, g, b, a;
     uint32_t width;
     uint32_t pad[3];  // Padding to align to 16 bytes
-} __attribute__((packed));
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 // The K-Means++ Initialization Function
 template <typename PixelT>

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 0.1.0 (2026-05-29)
+
+
+### ⚠ BREAKING CHANGES
+
+* **api:** remove draw_contour_borders from labels_to_svg ([#283](https://github.com/Ryan-Millard/Img2Num/issues/283))
+
+### ✨ Features
+
+* unified image_to_svg function as complete pipeline ([#335](https://github.com/Ryan-Millard/Img2Num/issues/335)) ([bdba68c](https://github.com/Ryan-Millard/Img2Num/commit/bdba68c8adbbf79a163aba9df25849c5ff36a6b9))
+
+
+### 🐛 Bug Fixes
+
+* **packages/js:** Remote property injection in wasmWorker.js ([#346](https://github.com/Ryan-Millard/Img2Num/issues/346)) ([dfe3afe](https://github.com/Ryan-Millard/Img2Num/commit/dfe3afe55dc380c89e9d8cb38df350a178ee3caf))
+
+
+### ⚡ Performance Improvements
+
+* **gpu:** add WebGPU acceleration with automatic fallback to CPU ([#272](https://github.com/Ryan-Millard/Img2Num/issues/272)) ([c385319](https://github.com/Ryan-Millard/Img2Num/commit/c3853198aaf72e00888352653bf44fe129261201))
+
+
+### ♻️ Refactoring
+
+* **api:** remove draw_contour_borders from labels_to_svg ([#283](https://github.com/Ryan-Millard/Img2Num/issues/283)) ([eee9b31](https://github.com/Ryan-Millard/Img2Num/commit/eee9b3135b5b651a20cc8ffab74bcef073b74b6a))

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "img2num",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Img2Num is a raster vectorization library - it converts images to SVGs",
   "publishConfig": {
     "access": "public"

--- a/packages/py/CHANGELOG.md
+++ b/packages/py/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 (2026-05-29)
+
+
+### ✨ Features
+
+* **python:** enable Python bindings via pybind11 and add console-py example ([#307](https://github.com/Ryan-Millard/Img2Num/issues/307)) ([294ae53](https://github.com/Ryan-Millard/Img2Num/commit/294ae53f4967495ff73c9c391bafc2e115a7eccf))
+* unified image_to_svg function as complete pipeline ([#335](https://github.com/Ryan-Millard/Img2Num/issues/335)) ([bdba68c](https://github.com/Ryan-Millard/Img2Num/commit/bdba68c8adbbf79a163aba9df25849c5ff36a6b9))

--- a/packages/py/pyproject.toml
+++ b/packages/py/pyproject.toml
@@ -2,4 +2,4 @@
 # The authoritative build config is the root pyproject.toml.
 [project]
 name = "img2num"
-version = "0.0.0"
+version = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ cmake.build-type = "Release"
 cmake.args = [
   "-DBUILD_PYTHON=ON",
   "-DPython3_FIND_VIRTUALENV=NEVER",
+  "-DIMG2NUM_BUILD_EXAMPLES=OFF",
 ]
 
 wheel.packages = ["img2num"]
@@ -49,7 +50,8 @@ sdist.include = [
   "CMakeLists.txt",
   "core/**",
   "bindings/py/**",
-  "packages/py/**"
+  "packages/py/**",
+  "third_party/**"
 ]
 
 [tool.uv]


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

v0.1.0 released very poorly - not even published to npm or pypi

This fixed that

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: none

## Changes

- MSVC compiler support for Windows
- Include `third_party/` for Python builds
- Fix npm publication job

## Testing & Verification

<!-- If there are tests, explain how you wrote them. Otherwise, explain how you know this works.  -->
<!-- This doesn't apply to docs -->

## Additional Resources

<!-- Extra information, e.g. screenshots -->
