### PR TITLE
fix: use length-aware string conversion for wgpu::StringView error logging

### DIFF
--- a/core/include/internal/gpu.h
+++ b/core/include/internal/gpu.h
@@ -229,7 +229,9 @@ class GPU {
                     device = std::move(d);
                     std::cout << "Device Acquired" << std::endl;
                 } else {
-                    std::cerr << "Device Failed: " << msg.data << std::endl;
+                    std::cerr << "Device Failed: "
+                    << (msg.data && msg.length > 0 ? std::string(msg.data, msg.length) : "Unknown error")
+                    << std::endl;
                 }
                 device_ready = true; // Unblock the loop
             }


### PR DESCRIPTION


## What was changed & why


Fixes: #401 as suggested

- used std::string(msg.data, msg.length) for length-aware conversion, replacing  direct streaming of wgpu::StringView::data in the device request failure callback 


## Changes

## Testing & Verification

## Additional Resources

<!-- Extra information, e.g. screenshots -->

<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->


