### PR TITLE
fix: replace C++20 designated initializers with C++17 compatible assignments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,8 @@ reviews:
     enabled: true
     auto_incremental_review: true
     drafts: false
+    base_branches:
+      - ".*"
     ignore_title_keywords:
       - "WIP"
       - "wip"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,19 @@
 # Img2Num Top-Level (Manages all libs and apps)
 # =================================================================
 cmake_minimum_required(VERSION 3.16)
-project(Img2Num LANGUAGES CXX)
+project(Img2NumRootManager LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Ensure we strictly conform to the C++17 standard
+# This is important for inter-OS reproducibility
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Reusable flags to ensure good quality code
+set(IMG2NUM_STRICT_CXX_FLAGS
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-Wpedantic -Werror=pedantic -Werror=c++20-extensions>
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/permissive->
+)
 
 option(BUILD_PYTHON "Build Python bindings" OFF)
 option(IMG2NUM_BUILD_EXAMPLES "Build example applications" ON)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -1,9 +1,6 @@
 # =================================================================
 # Img2Num C Bindings
 # =================================================================
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 project(CImg2Num
   LANGUAGES CXX
   # Don't change the inline comment below - release-please needs it
@@ -20,6 +17,8 @@ set(C_BINDINGS_SRC
 )
 
 add_library(CImg2Num ${C_BINDINGS_SRC})
+
+target_compile_options(CImg2Num PRIVATE ${IMG2NUM_STRICT_CXX_FLAGS})
 
 set_target_properties(CImg2Num PROPERTIES
   VERSION ${PROJECT_VERSION}

--- a/bindings/c/src/cimg2num.cpp
+++ b/bindings/c/src/cimg2num.cpp
@@ -8,41 +8,35 @@
 extern "C" {
 
 static img2num::ImageToSvgConfig to_cpp(const img2num_ImageToSvgConfig& c) {
-    // clang-format off
-    return {
-        .bilateral_filter {
-            .sigma_spatial = c.bilateral_filter.sigma_spatial,
-            .sigma_range = c.bilateral_filter.sigma_range
-        },
+    img2num::ImageToSvgConfig cfg {};
 
-        .kmeans {
-            .k = c.kmeans.k,
-            .max_iter = c.kmeans.max_iter
-        },
+    cfg.bilateral_filter.sigma_spatial = c.bilateral_filter.sigma_spatial;
+    cfg.bilateral_filter.sigma_range   = c.bilateral_filter.sigma_range;
 
-        .min_cluster_area = c.min_cluster_area,
-        .min_thickness = c.min_thickness,
-        .color_space = c.color_space
-    };
-    // clang-format on
+    cfg.kmeans.k                       = c.kmeans.k;
+    cfg.kmeans.max_iter                = c.kmeans.max_iter;
+
+    cfg.min_cluster_area               = c.min_cluster_area;
+    cfg.min_thickness                  = c.min_thickness;
+    cfg.color_space                    = c.color_space;
+
+    return cfg;
 }
 
 static img2num_ImageToSvgConfig to_c(const img2num::ImageToSvgConfig& cpp) {
-    // clang-format off
-    return {
-        .bilateral_filter {
-            .sigma_spatial = cpp.bilateral_filter.sigma_spatial,
-            .sigma_range = cpp.bilateral_filter.sigma_range
-        },
-        .kmeans{
-            .k = cpp.kmeans.k,
-            .max_iter = cpp.kmeans.max_iter
-        },
-        .min_cluster_area = cpp.min_cluster_area,
-        .min_thickness = cpp.min_thickness,
-        .color_space = cpp.color_space
-    };
-    // clang-format on
+    img2num_ImageToSvgConfig cfg {};
+
+    cfg.bilateral_filter.sigma_spatial = cpp.bilateral_filter.sigma_spatial;
+    cfg.bilateral_filter.sigma_range   = cpp.bilateral_filter.sigma_range;
+
+    cfg.kmeans.k                       = cpp.kmeans.k;
+    cfg.kmeans.max_iter                = cpp.kmeans.max_iter;
+
+    cfg.min_cluster_area               = cpp.min_cluster_area;
+    cfg.min_thickness                  = cpp.min_thickness;
+    cfg.color_space                    = cpp.color_space;
+
+    return cfg;
 }
 
 img2num_ImageToSvgConfig img2num_ImageToSvgConfig_default(void) {

--- a/bindings/py/CMakeLists.txt
+++ b/bindings/py/CMakeLists.txt
@@ -1,9 +1,6 @@
 # =================================================================
 # Img2Num Python Bindings
 # =================================================================
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 project(PyImg2Num
   LANGUAGES CXX
   VERSION 0.0.0
@@ -12,9 +9,6 @@ project(PyImg2Num
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 set(PYBIND11_FINDPYTHON ON)
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
 find_package(pybind11 REQUIRED)
@@ -22,7 +16,10 @@ find_package(pybind11 REQUIRED)
 file(GLOB BINDING_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
 )
+
 pybind11_add_module(_img2num MODULE ${BINDING_SRC})
+
+target_compile_options(_img2num PRIVATE ${IMG2NUM_STRICT_CXX_FLAGS})
 
 target_link_libraries(_img2num PRIVATE Img2Num)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,9 +1,6 @@
 # =================================================================
 # Img2Num Core (C++)
 # =================================================================
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 project(Img2Num
   LANGUAGES CXX
   # Don't change the inline comment below - release-please needs it
@@ -40,6 +37,8 @@ add_custom_target(Img2Num_shaders ALL
 )
 
 add_library(Img2Num ${CORE_SRC})
+
+target_compile_options(Img2Num PRIVATE ${IMG2NUM_STRICT_CXX_FLAGS})
 
 set_target_properties(Img2Num PROPERTIES
   VERSION ${PROJECT_VERSION}

--- a/example-apps/console-c/CMakeLists.txt
+++ b/example-apps/console-c/CMakeLists.txt
@@ -1,8 +1,7 @@
 # =================================================================
 # Example Console App (C)
 # =================================================================
-cmake_minimum_required(VERSION 3.16)
-project(Img2NumExample LANGUAGES C)
+project(CImg2NumExample_console_c LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -11,17 +10,19 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(EXAMPLE_SRC main.c)
 
 # Build executable
-add_executable(console_c_app ${EXAMPLE_SRC})
+add_executable(CImg2NumExample_console_c ${EXAMPLE_SRC})
+
+target_compile_options(CImg2NumExample_console_c PRIVATE ${IMG2NUM_STRICT_CXX_FLAGS})
 
 # Include the downloaded headers directly
-target_include_directories(console_c_app PRIVATE
+target_include_directories(CImg2NumExample_console_c PRIVATE
   ${CMAKE_SOURCE_DIR}/third_party
 )
 
 # Location to store the output images
-target_compile_definitions(console_c_app PRIVATE
+target_compile_definitions(CImg2NumExample_console_c PRIVATE
   OUTPUT_DIR="${CMAKE_BINARY_DIR}/outputs/console-c"
 )
 
 # Link against the C bindings
-target_link_libraries(console_c_app PRIVATE CImg2Num m)
+target_link_libraries(CImg2NumExample_console_c PRIVATE CImg2Num m)

--- a/example-apps/console-cpp/CMakeLists.txt
+++ b/example-apps/console-cpp/CMakeLists.txt
@@ -1,27 +1,25 @@
 # =================================================================
 # Example Console App (C++)
 # =================================================================
-cmake_minimum_required(VERSION 3.16)
-project(Img2NumExample LANGUAGES CXX)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(Img2NumExample_console_cpp LANGUAGES CXX)
 
 # Collect source files
 file(GLOB_RECURSE EXAMPLE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
 # Build executable
-add_executable(console_cpp_app ${EXAMPLE_SRC})
+add_executable(Img2NumExample_console_cpp ${EXAMPLE_SRC})
+
+target_compile_options(Img2NumExample_console_cpp PRIVATE ${IMG2NUM_STRICT_CXX_FLAGS})
 
 # Include the downloaded STB headers
-target_include_directories(console_cpp_app PRIVATE
+target_include_directories(Img2NumExample_console_cpp PRIVATE
   ${CMAKE_SOURCE_DIR}/third_party
 )
 
 # Location to store the output images
-target_compile_definitions(console_cpp_app PRIVATE
+target_compile_definitions(Img2NumExample_console_cpp PRIVATE
   OUTPUT_DIR="${CMAKE_BINARY_DIR}/outputs/console-cpp"
 )
 
 # Link against the core Img2Num library
-target_link_libraries(console_cpp_app PRIVATE Img2Num)
+target_link_libraries(Img2NumExample_console_cpp PRIVATE Img2Num)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ cmake.source-dir = "."
 cmake.build-type = "Release"
 cmake.args = [
   "-DBUILD_PYTHON=ON",
-  "-DPython3_FIND_VIRTUALENV=NEVER",
   "-DIMG2NUM_BUILD_EXAMPLES=OFF",
 ]
 


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

Add strict CMake flags to avoid MSVC errors during builds.

**Motivation:** [This workflow failure](https://github.com/Ryan-Millard/Img2Num/actions/runs/27877841326/job/82500249080) on the `dev` branch.

## Changes

- CMake build flags to  enforce C++17 strictly
- refactor `bindings/c/src/cimg2num.cpp` to conform to C++17
