### PR TITLE
build: fix `release.yml` build errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release (release-please, multi-language assets)
 on:
   push:
     branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
 
 jobs:
   release-please:
@@ -78,12 +80,14 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.component }}" == "c" ]]; then
-            echo "created=${{ needs.release-please.outputs.c_created }}"   >> $GITHUB_OUTPUT
-            echo "tag=${{ needs.release-please.outputs.c_tag }}"           >> $GITHUB_OUTPUT
+            echo "IMG2NUM_BUILD_C_VAL=ON"                                               >> $GITHUB_OUTPUT
+            echo "created=${{ needs.release-please.outputs.c_created }}"                >> $GITHUB_OUTPUT
+            echo "tag=${{ needs.release-please.outputs.c_tag }}"                        >> $GITHUB_OUTPUT
             echo "version=${{ needs.release-please.outputs.c_version || '0.0.0-dev' }}" >> $GITHUB_OUTPUT
           else
-            echo "created=${{ needs.release-please.outputs.cpp_created }}" >> $GITHUB_OUTPUT
-            echo "tag=${{ needs.release-please.outputs.cpp_tag }}"         >> $GITHUB_OUTPUT
+            echo "IMG2NUM_BUILD_C_VAL=OFF"                                                >> $GITHUB_OUTPUT
+            echo "created=${{ needs.release-please.outputs.cpp_created }}"                >> $GITHUB_OUTPUT
+            echo "tag=${{ needs.release-please.outputs.cpp_tag }}"                        >> $GITHUB_OUTPUT
             echo "version=${{ needs.release-please.outputs.cpp_version || '0.0.0-dev' }}" >> $GITHUB_OUTPUT
           fi
 
@@ -96,7 +100,15 @@ jobs:
 
       - name: Configure
         if: ${{ steps.component.outputs.created == 'true' || needs.release-please.outputs.is_dry_run == 'true' }}
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+        shell: bash
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install \
+            -DIMG2NUM_BUILD_C=${{ steps.component.outputs.IMG2NUM_BUILD_C_VAL }} \
+            -DIMG2NUM_BUILD_PYTHON=OFF \
+            -DIMG2NUM_BUILD_EXAMPLES=OFF \
+            -DIMG2NUM_DEBUG_CACHE_VARIABLES_DUMP=ON
 
       - name: Build
         if: ${{ steps.component.outputs.created == 'true' || needs.release-please.outputs.is_dry_run == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main, dev]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Release (release-please, multi-language assets)
 on:
   push:
     branches: [main, dev]
-  pull_request:
-    branches: [main, dev]
 
 jobs:
   release-please:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,10 @@ set(IMG2NUM_STRICT_CXX_FLAGS
     $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/permissive->
 )
 
-option(BUILD_PYTHON "Build Python bindings" OFF)
+option(IMG2NUM_BUILD_C "Build C bindings" ON)
+option(IMG2NUM_BUILD_PYTHON "Build Python bindings" OFF)
 option(IMG2NUM_BUILD_EXAMPLES "Build example applications" ON)
+option(IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP "Dump CMake environment variables in Debug mode" ON)
 
 # Force a safe default to avoid the weirdness of CMake's `None`
 if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
@@ -25,27 +27,68 @@ if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build" FORCE)
 endif()
 
-message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+# Debug variable dump during "cmake -B..."
+block()
+if(IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP)
+  string(ASCII 27 ESC)
+  set(COLOR_MAGENTA "${ESC}[35m")
+  set(COLOR_YELLOW "${ESC}[33m")
+  set(COLOR_CYAN "${ESC}[36m")
+  set(COLOR_RESET "${ESC}[0m")
 
-# Core library
+  message(STATUS "${COLOR_YELLOW}===============================================================${COLOR_RESET}")
+  message(STATUS "${COLOR_YELLOW}IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP Output:${COLOR_RESET}")
+  message(STATUS "${COLOR_YELLOW}===============================================================${COLOR_RESET}")
+
+  get_cmake_property(_vars CACHE_VARIABLES)
+  list(SORT _vars)
+
+  foreach(_var ${_vars})
+    string(TOUPPER "${_var}" _var_upper)
+
+    if(_var MATCHES "^IMG2NUM")
+      message(STATUS "[User-Defined] ${COLOR_MAGENTA}${_var}=${${_var}}${COLOR_RESET}")
+    elseif(_var_upper MATCHES "^IMG2NUM")
+      message(STATUS "[Auto] ${COLOR_CYAN}${_var}=${${_var}}${COLOR_RESET}")
+    endif()
+  endforeach()
+
+  foreach(_var ${_vars})
+    string(TOUPPER "${_var}" _var_upper)
+
+    if(NOT _var_upper MATCHES "^IMG2NUM")
+      message(STATUS "${COLOR_YELLOW}${_var}=${${_var}}${COLOR_RESET}")
+    endif()
+  endforeach()
+
+  message(STATUS "${COLOR_YELLOW}===============================================================\n\n${COLOR_RESET}")
+endif()
+endblock()
+
+# ================================================
+# Library setup
+
+# Always add core because everything depends on it
 add_subdirectory(core)
 
-# C bindings
-add_subdirectory(bindings/c)
-
-if(EMSCRIPTEN)
-  # JS bindings
+if(IMG2NUM_BUILD_PYTHON)
+  # Python depends only on core
+  add_subdirectory(bindings/py)
+elseif(IMG2NUM_BUILD_C)
+  # C depends only on core
+  add_subdirectory(bindings/c)
+elseif(EMSCRIPTEN)
+  # WebAssembly relies on C
+  add_subdirectory(bindings/c)
   add_subdirectory(bindings/js)
-else()
-  # Python bindings
-  if(BUILD_PYTHON)
-    add_subdirectory(bindings/py)
-  endif()
-  
-  if(IMG2NUM_BUILD_EXAMPLES)
-    # Example console app (C++)
-    add_subdirectory(example-apps/console-cpp)
-    # Example console app (C)
+endif()
+
+# ================================================
+# Example apps (Emscripten can't compile them)
+if(NOT EMSCRIPTEN AND IMG2NUM_BUILD_EXAMPLES)
+  add_subdirectory(example-apps/console-cpp)
+
+  if(IMG2NUM_BUILD_C)
     add_subdirectory(example-apps/console-c)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,12 @@ block()
 if(IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP)
   string(ASCII 27 ESC)
   set(COLOR_MAGENTA "${ESC}[35m")
-  set(COLOR_YELLOW "${ESC}[33m")
   set(COLOR_CYAN "${ESC}[36m")
   set(COLOR_RESET "${ESC}[0m")
 
-  message(STATUS "${COLOR_YELLOW}===============================================================${COLOR_RESET}")
-  message(STATUS "${COLOR_YELLOW}IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP Output:${COLOR_RESET}")
-  message(STATUS "${COLOR_YELLOW}===============================================================${COLOR_RESET}")
+  message(STATUS "===============================================================")
+  message(STATUS "IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP Output:")
+  message(STATUS "===============================================================")
 
   get_cmake_property(_vars CACHE_VARIABLES)
   list(SORT _vars)
@@ -57,11 +56,11 @@ if(IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP)
     string(TOUPPER "${_var}" _var_upper)
 
     if(NOT _var_upper MATCHES "^IMG2NUM")
-      message(STATUS "${COLOR_YELLOW}${_var}=${${_var}}${COLOR_RESET}")
+      message(STATUS "${_var}=${${_var}}")
     endif()
   endforeach()
 
-  message(STATUS "${COLOR_YELLOW}===============================================================\n\n${COLOR_RESET}")
+  message(STATUS "===============================================================\n\n")
 endif()
 endblock()
 
@@ -74,10 +73,24 @@ add_subdirectory(core)
 if(IMG2NUM_BUILD_PYTHON)
   # Python depends only on core
   add_subdirectory(bindings/py)
-elseif(IMG2NUM_BUILD_C)
+elseif(IMG2NUM_BUILD_C AND NOT EMSCRIPTEN)
   # C depends only on core
   add_subdirectory(bindings/c)
 elseif(EMSCRIPTEN)
+  # Check if the user tried to disable C bindings under Emscripten
+  if(NOT IMG2NUM_BUILD_C)
+    string(ASCII 27 ESC)
+    set(COLOR_RED "${ESC}[31m")
+    set(COLOR_RESET "${ESC}[0m")
+    message(WARNING 
+      "${COLOR_RED}IMG2NUM_BUILD_C was disabled under Emscripten! "
+      "WebAssembly compilation absolutely requires the C bindings. "
+      "Forcing IMG2NUM_BUILD_C=ON to prevent a broken build.${COLOR_RESET}"
+    )
+    # Force the option back to ON in the cache
+    set(IMG2NUM_BUILD_C ON CACHE BOOL "Build C bindings" FORCE)
+  endif()
+
   # WebAssembly relies on C
   add_subdirectory(bindings/c)
   add_subdirectory(bindings/js)

--- a/Justfile
+++ b/Justfile
@@ -85,8 +85,8 @@ console-py input:
 
 console-cpp input:
     @echo "./build-c-cpp/example-apps/console-cpp/console_cpp_app {{ input }}"
-    ./build-c-cpp/example-apps/console-cpp/console_cpp_app "{{ input }}"
+    ./build-c-cpp/example-apps/console-cpp/Img2NumExample_console_cpp "{{ input }}"
 
 console-c input:
     @echo "./build-c-cpp/example-apps/console-c/console_c_app {{ input }}"
-    ./build-c-cpp/example-apps/console-c/console_c_app "{{ input }}"
+    ./build-c-cpp/example-apps/console-c/CImg2NumExample_console_c "{{ input }}"

--- a/bindings/py/CMakeLists.txt
+++ b/bindings/py/CMakeLists.txt
@@ -10,7 +10,7 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 set(PYBIND11_FINDPYTHON ON)
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module NumPy)
 find_package(pybind11 REQUIRED)
 
 file(GLOB BINDING_SRC

--- a/bindings/py/src/img2num_pybind.cpp
+++ b/bindings/py/src/img2num_pybind.cpp
@@ -98,7 +98,7 @@ PYBIND11_MODULE(_img2num, m) {
 
             // Allocate NumPy arrays for the outputs
             auto out_data = pybind11::array_t<uint8_t>(data_buf.shape);
-            auto out_labels = pybind11::array_t<int32_t>({(ssize_t)height, (ssize_t)width});
+            auto out_labels = pybind11::array_t<int32_t>({static_cast<size_t>(height), static_cast<size_t>(width)});
 
             auto out_data_ptr = static_cast<uint8_t*>(out_data.mutable_data());
             auto out_labels_ptr = static_cast<int32_t*>(out_labels.mutable_data());

--- a/example-apps/console-c/CMakeLists.txt
+++ b/example-apps/console-c/CMakeLists.txt
@@ -25,4 +25,4 @@ target_compile_definitions(CImg2NumExample_console_c PRIVATE
 )
 
 # Link against the C bindings
-target_link_libraries(CImg2NumExample_console_c PRIVATE CImg2Num m)
+target_link_libraries(CImg2NumExample_console_c PRIVATE CImg2Num)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build-backend = "scikit_build_core.build"
 cmake.source-dir = "."
 cmake.build-type = "Release"
 cmake.args = [
-  "-DBUILD_PYTHON=ON",
+  "-DIMG2NUM_BUILD_PYTHON=ON",
   "-DIMG2NUM_BUILD_EXAMPLES=OFF",
 ]
 
@@ -87,3 +87,5 @@ dev = [
   "ruff>=0.4.0",
 ]
 
+[tool.cibuildwheel]
+build-verbosity = 1


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

<!-- A sentence or two describing the change. -->
<!-- A brief motivation for this change -->

<!-- Use the fixes keyword below and the issue related to this PR to link them. -->

Fixes: #432

- Fix build failures in .github/workflows/release.yml by expanding the
CMake Configure step to pass the full set of required options, including
an IMG2NUM_BUILD_C toggle derived from component metadata, and disabling
Python/examples builds during the native C/C++ build phase.

- Standardise all project-level CMake cache variables under the IMG2NUM_
namespace (IMG2NUM_BUILD_C, IMG2NUM_BUILD_PYTHON, IMG2NUM_BUILD_EXAMPLES,
IMG2NUM_DEBUG_CACHE_VARIABLES_DUMP) and make subdirectory inclusion
conditional on these flags. Add an optional ANSI-coloured cache-variable
debug dump to aid configuration inspection.

- Update pyproject.toml to use the renamed -DIMG2NUM_BUILD_PYTHON=ON flag
and add a [tool.cibuildwheel] section with build-verbosity = 1.

- Fix the Python bindings CMake to require Development.Module instead of
Development when locating Python3, resolving scikit-build-core
compatibility issues.

- The release workflow dry-runs on dev and publishes to PyPI only when
triggered by release-please on main. Caching of Dawn build artifacts
across cibuildwheel runs can be explored in a follow-up PR.