### PR TITLE
Docs: replace raw setup/build commands with just tasks

### DIFF
--- a/bindings/c/src/cimg2num.cpp
+++ b/bindings/c/src/cimg2num.cpp
@@ -11,14 +11,14 @@ static img2num::ImageToSvgConfig to_cpp(const img2num_ImageToSvgConfig& c) {
     img2num::ImageToSvgConfig cfg {};
 
     cfg.bilateral_filter.sigma_spatial = c.bilateral_filter.sigma_spatial;
-    cfg.bilateral_filter.sigma_range   = c.bilateral_filter.sigma_range;
+    cfg.bilateral_filter.sigma_range = c.bilateral_filter.sigma_range;
 
-    cfg.kmeans.k                       = c.kmeans.k;
-    cfg.kmeans.max_iter                = c.kmeans.max_iter;
+    cfg.kmeans.k = c.kmeans.k;
+    cfg.kmeans.max_iter = c.kmeans.max_iter;
 
-    cfg.min_cluster_area               = c.min_cluster_area;
-    cfg.min_thickness                  = c.min_thickness;
-    cfg.color_space                    = c.color_space;
+    cfg.min_cluster_area = c.min_cluster_area;
+    cfg.min_thickness = c.min_thickness;
+    cfg.color_space = c.color_space;
 
     return cfg;
 }
@@ -27,14 +27,14 @@ static img2num_ImageToSvgConfig to_c(const img2num::ImageToSvgConfig& cpp) {
     img2num_ImageToSvgConfig cfg {};
 
     cfg.bilateral_filter.sigma_spatial = cpp.bilateral_filter.sigma_spatial;
-    cfg.bilateral_filter.sigma_range   = cpp.bilateral_filter.sigma_range;
+    cfg.bilateral_filter.sigma_range = cpp.bilateral_filter.sigma_range;
 
-    cfg.kmeans.k                       = cpp.kmeans.k;
-    cfg.kmeans.max_iter                = cpp.kmeans.max_iter;
+    cfg.kmeans.k = cpp.kmeans.k;
+    cfg.kmeans.max_iter = cpp.kmeans.max_iter;
 
-    cfg.min_cluster_area               = cpp.min_cluster_area;
-    cfg.min_thickness                  = cpp.min_thickness;
-    cfg.color_space                    = cpp.color_space;
+    cfg.min_cluster_area = cpp.min_cluster_area;
+    cfg.min_thickness = cpp.min_thickness;
+    cfg.color_space = cpp.color_space;
 
     return cfg;
 }

--- a/bindings/py/src/img2num_pybind.cpp
+++ b/bindings/py/src/img2num_pybind.cpp
@@ -98,7 +98,9 @@ PYBIND11_MODULE(_img2num, m) {
 
             // Allocate NumPy arrays for the outputs
             auto out_data = pybind11::array_t<uint8_t>(data_buf.shape);
-            auto out_labels = pybind11::array_t<int32_t>({static_cast<size_t>(height), static_cast<size_t>(width)});
+            auto out_labels =
+                pybind11::array_t<int32_t>({static_cast<size_t>(height), static_cast<size_t>(width)}
+                );
 
             auto out_data_ptr = static_cast<uint8_t*>(out_data.mutable_data());
             auto out_labels_ptr = static_cast<int32_t*>(out_labels.mutable_data());

--- a/docs/docs/contributing/setup-and-dependencies/index.md
+++ b/docs/docs/contributing/setup-and-dependencies/index.md
@@ -54,7 +54,7 @@ This clones all submodules:
 - `dawn` (optional, required for local native builds)
 
 ```bash
-git submodule update --init third_party
+just init
 ```
 
   </TabItem>
@@ -204,8 +204,7 @@ values={[
 <TabItem value="release">
 
 ```bash title="Compile Release build"
-cmake -B build-release/ .
-cmake --build build-release/
+just cxx build
 ```
 
 </TabItem>
@@ -245,8 +244,7 @@ values={[
 <TabItem value="release">
 
 ```bash title="Compile Release build"
-emcmake cmake -B build-wasm-release/ .
-cmake --build build-wasm-release/
+just build js
 ```
 
 </TabItem>
@@ -295,13 +293,13 @@ values={[
 <TabItem value="react-example">
 
 ```bash
-pnpm -F react-example dev
+just react-js start
 ```
 
 </TabItem>
 <TabItem value="docs">
 ```bash
-pnpm -F docs start
+just docs start
 ```
 </TabItem>
 </Tabs>

--- a/docs/docs/internal/bindings/c/index.md
+++ b/docs/docs/internal/bindings/c/index.md
@@ -30,8 +30,7 @@ Each function is fully documented with Doxygen and mirrors the corresponding C++
 ## Building the C Bindings
 
 ```bash title="Run this in the root of the project"
-cmake -B build .
-cmake --build build
+just cxx build
 cmake --install build
 ```
 

--- a/docs/docs/internal/bindings/js/index.md
+++ b/docs/docs/internal/bindings/js/index.md
@@ -28,8 +28,7 @@ Each function is documented with Doxygen and mirrors the functionality of the co
 ## Building the WASM Module
 
 ```bash title="Run this in the root of the project"
-emcmake cmake -B build-wasm .
-cmake --build build-wasm
+just build js
 ```
 
 * The module outputs `index.js` and `index.wasm` in `packages/js/build-wasm`.

--- a/docs/docs/internal/example-apps/console-c-and-console-cpp/index.md
+++ b/docs/docs/internal/example-apps/console-c-and-console-cpp/index.md
@@ -23,8 +23,8 @@ See the [Setup & Dependencies](../../../contributing/setup-and-dependencies) pag
 :::note
 If you have already set up the project, you will only need to run the below to build these apps:
 
-```cpp
-cmake -S . --build build
+```bash
+just cxx build
 ```
 
 :::
@@ -43,11 +43,10 @@ import TabItem from "@theme/TabItem";
 <Tabs defaultValue="cpp">
 <TabItem value="cpp" label="C++ console app">
 ```bash title="Run this from the root of the project"
-./console_cpp_app <image_file>
+just console-cpp <image_file>
 ```
-
 ```bash title="Example usage"
-./build/example-apps/console-cpp/console_cpp_app test.jpg
+just console-cpp test.jpg
 ```
 
 > **Expected Output**: `console-cpp-output.png` in the root of the project.
@@ -56,11 +55,11 @@ import TabItem from "@theme/TabItem";
 <TabItem value="c" label="C console app">
 
 ```bash title="Run this from the root of the project"
-./console_c_app <image_file>
+just console-c <image_file>
 ```
 
 ```bash title="Example usage"
-./build/example-apps/console-c/console_c_app test.jpg
+just console-c test.jpg
 ```
 
 > **Expected Output**: `console-c-output.png` in the root of the project.

--- a/docs/docs/internal/scripts/help-scripts/index.md
+++ b/docs/docs/internal/scripts/help-scripts/index.md
@@ -20,7 +20,7 @@ Both provide the same interface, but are scoped to their `package.json` scripts.
 Run the following command from the project root:
 
 ```bash
-npm run help
+just help
 ```
 
 This launches an interactive CLI that shows all scripts in `package.json` grouped by category and allows fuzzy search.

--- a/docs/docs/internal/scripts/help-scripts/scripts-guide.md
+++ b/docs/docs/internal/scripts/help-scripts/scripts-guide.md
@@ -118,7 +118,7 @@ This ensures documentation for scripts can't be accidentally left out of a PR.
 ### Usage Examples
 
 ```bash title="Run the help CLI from the repo root"
-npm run help
+just help
 ```
 
 ```bash title="Arguments (immediately passed to fuzzy search)"


### PR DESCRIPTION
## What was changed & why

Updated the contributor documentation to use `just` commands instead of raw build/setup commands where equivalent `just` tasks are available.

Fixes: #443 

## Changes

- Updated setup and build instructions to use `just` commands.
- Replaced raw build/run commands with `just` equivalents where applicable.
- Updated documentation for C/C++, JS/WASM, and console examples.

## Testing & Verification

- Verified the documentation builds successfully with `just docs build`.
- Verified the documentation serves correctly with `just docs start`.

## Additional Resources

N/A