### PR TITLE
chore(.github/dependabot.yml): change to target dev branch rather than default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    target-branch: "dev"
     groups:
       all-deps:
         patterns:
@@ -27,6 +28,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    target-branch: "dev"
     groups:
       all-deps:
         patterns:
@@ -46,6 +48,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    target-branch: "dev"
     groups:
       all-deps:
         patterns:
@@ -65,6 +68,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    target-branch: "dev"
     groups:
       all-deps:
         patterns:
@@ -85,6 +89,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    target-branch: "dev"
     groups:
       all-actions:
         patterns:
@@ -95,3 +100,4 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "ci(deps)"
+


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## What was changed & why

`.github/dependabot.yml` got an update so it stops annoying me and making me almost accidentally merge directly into the `main` branch.

## Changes

- `.github/dependabot.yml`