### PR TITLE
docs(main): fix changelog header inlining bug

### DIFF
--- a/docs/plugins/changelogPlugin/generators/consolidatedFile.js
+++ b/docs/plugins/changelogPlugin/generators/consolidatedFile.js
@@ -28,7 +28,7 @@ ${trimTrailing(body)}`;
     PACKAGE_LABEL: pkg.label,
     PACKAGE_NAME: pkg.packageName,
     RELEASES_URL: githubReleasesPageLink,
-    RELEASES: sections.join("\n\n"),
+    RELEASES: sections.join("\n---\n"),
   });
 
   writeFile(filePath, content);

--- a/docs/plugins/changelogPlugin/generators/consolidatedFile.js
+++ b/docs/plugins/changelogPlugin/generators/consolidatedFile.js
@@ -1,8 +1,8 @@
-import { writeFile } from "../fs";
 import path from "path";
+import { writeFile } from "../fs";
 import frontMatter from "./frontMatter";
-import trimTrailing from "./trimTrailing";
 import renderTemplate from "./renderTemplate.js";
+import trimTrailing from "./trimTrailing";
 
 export default function consolidatedFile(releases, pkg, outDir) {
   const filePath = path.join(outDir, "changelog.md");
@@ -28,7 +28,7 @@ ${trimTrailing(body)}`;
     PACKAGE_LABEL: pkg.label,
     PACKAGE_NAME: pkg.packageName,
     RELEASES_URL: githubReleasesPageLink,
-    RELEASES: sections,
+    RELEASES: sections.join("\n\n"),
   });
 
   writeFile(filePath, content);


### PR DESCRIPTION
## Changes & Reason

### Changes
- Fixed `consolidatedFile.js`
- Changed `RELEASES: sections` to `RELEASES: sections.join("\n\n")`

### Reason
- Prevents array-to-string conversion issues causing broken MDX headings
- Ensures proper release section formatting in changelog output

## Related Issues
Fixes: #468 

## Testing & Verification
- Checked changelog rendering for multiple releases
- Verified correct heading separation (no inline/comma output)

## Additional Resources
N/A