### PR TITLE
docs(pyproject.toml): fix changelog URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 Homepage      = "https://img2num.dev"
 Repository    = "https://github.com/Ryan-Millard/Img2Num"
 Documentation = "https://img2num.dev/docs/"
-Changelog     = "https://github.com/Ryan-Millard/Img2Num/blob/main/CHANGELOG.md"
+Changelog     = "https://img2num.dev/changelog/py/"
+"Changelog (GitHub)" = "https://github.com/Ryan-Millard/Img2Num/blob/main/packages/py/CHANGELOG.md"
 "Bug Tracker" = "https://github.com/Ryan-Millard/Img2Num/issues"
 
 [build-system]


### PR DESCRIPTION
## Changes & Reason

### Changes
- Point the primary Python changelog URL to the Img2Num documentation site.
- Add a separate GitHub changelog URL targeting the actual Python package changelog.

### Reason
The existing metadata link targets a root-level `CHANGELOG.md` that does not exist. Publishing both working links gives package users a rendered changelog and a direct source-file option.

## Related Issues

Fixes: #537

## Testing & Verification

- Parsed `pyproject.toml` with Python `tomllib` and asserted both metadata values.
- Confirmed both replacement URLs return HTTP 200.
- Ran `git diff --check`.

## Additional Resources

N/A