### PR TITLE
ci(releases): install just in build-js job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,10 @@ jobs:
         with:
           version: 11.4.0
 
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        with:
+          just-version: '1.46.0'
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
The packages/js build script delegates to just, which is not preinstalled on GitHub runners, causing pnpm build to fail with "just: not found". Pin extractions/setup-just to v4.0.0.

<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## Changes & Reason

### Changes
Add just to build-js job in `release.yml`

### Reason
Previously failed because the other CI workflows use `Dockerfile.dev`, but this one is pure.