### PR TITLE
fix(docs): escape MDX-hostile braces and angle brackets in changelog bodies

### DIFF
--- a/docs/plugins/changelogPlugin/core/parseChangelog.js
+++ b/docs/plugins/changelogPlugin/core/parseChangelog.js
@@ -1,3 +1,6 @@
+import compareSemver from "./compareSemver";
+import sanitizeMdxBody from "./sanitizeMdxBody";
+
 export default function parseChangelog(raw) {
   const RELEASE_HEADING =
     /^## (?:\[)?(\d+\.\d+\.\d+[^)\] ]*)(?:\][^)]*\))?(?: \((\d{4}-\d{2}-\d{2})\))?/;
@@ -26,5 +29,5 @@ export default function parseChangelog(raw) {
     return compareSemver(b.version, a.version);
   });
 
-  return releases;
+  return releases.map((r) => ({ ...r, body: sanitizeMdxBody(r.body) }));
 }

--- a/docs/plugins/changelogPlugin/core/sanitizeMdxBody.js
+++ b/docs/plugins/changelogPlugin/core/sanitizeMdxBody.js
@@ -9,6 +9,7 @@ export default function sanitizeMdxBody(body) {
     .map((seg, i) => {
       if (i % 2 === 1) return seg; // inside code — MDX already ignores these
       return seg
+        .replace(/\\/g, "\\\\")
         .replace(/([{}])/g, "\\$1")
         .replace(/</g, "\\<");
     })

--- a/docs/plugins/changelogPlugin/core/sanitizeMdxBody.js
+++ b/docs/plugins/changelogPlugin/core/sanitizeMdxBody.js
@@ -1,0 +1,16 @@
+/**
+ * Escape MDX-hostile characters in changelog bodies.
+ * Braces become JSX expressions and stray `<` becomes a JSX tag open,
+ * both of which crash SSG. Code spans/fences are left untouched.
+ */
+export default function sanitizeMdxBody(body) {
+  return body
+    .split(/(```[\s\S]*?```|`[^`\n]+`)/g)
+    .map((seg, i) => {
+      if (i % 2 === 1) return seg; // inside code — MDX already ignores these
+      return seg
+        .replace(/([{}])/g, "\\$1")
+        .replace(/</g, "\\<");
+    })
+    .join("");
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## Changes & Reason

### Changes
Escape MDX characters to avoid parsing them as intentional JSX. This keeps us on Markdown-only styles.

### Reason
#554 had build errors because of this.