### PR TITLE
fix(js): restore static wasm URL for bundler asset detection

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -43,7 +43,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "sideEffects": [
     "**/*.wasm",

--- a/packages/js/vite.config.js
+++ b/packages/js/vite.config.js
@@ -62,25 +62,6 @@ if (!T) {
 }
 
 /**
- * Vite inlines `new URL('x.wasm', import.meta.url)` as a data URL in lib mode
- *  and ignores assetsInlineLimit. Hoisting the literal defeats the static
- *  analysis, leaving a real runtime URL resolution against the sibling file.
- */
-function preventWasmInlining() {
-  return {
-    name: "img2num:prevent-wasm-inlining",
-    enforce: "pre",
-    transform(code, id) {
-      if (!id.includes("build-wasm") || !T.copyWasm) return null;
-      if (!code.includes("import.meta.url")) return null;
-
-      const patched = code.replace(/new URL\((["'])(img2num\.wasm)\1,\s*import\.meta\.url\)/g, 'new URL(globalThis.__IMG2NUM_WASM_NAME__ ??= "$2", import.meta.url)');
-      return patched === code ? null : { code: patched, map: null };
-    },
-  };
-}
-
-/**
  * Copies the emitted .wasm into dist/<target>/ after the bundle is written.
  */
 function copyWasmPlugin() {
@@ -103,6 +84,65 @@ function copyWasmPlugin() {
   };
 }
 
+/**
+ * Ships a bundler-detectable wasm URL in the published output.
+ *
+ * Problem: Vite's lib mode inlines `new URL("x.wasm", import.meta.url)` as a
+ * data URL and ignores assetsInlineLimit. But downstream bundlers (Vite,
+ * webpack 5, Rollup, Parcel) rely on that exact literal form to detect,
+ * emit, and rewrite the wasm asset in *consumer* builds.
+ *
+ * Solution, in two phases:
+ *   1. transform: mangle the literal into a non-static expression so
+ *      lib-mode asset analysis can't inline it.
+ *   2. generateBundle: after analysis is done, restore the literal in the
+ *      emitted chunk so consumers' bundlers can see it.
+ *
+ * LOAD-BEARING CONSTRAINT: the mangled sentinel must be valid syntax at
+ * build.target (es2020). Do NOT use `??=` or other ES2021+ operators here —
+ * they get transpiled before generateBundle runs, the restore match fails
+ * silently, and the published chunk ships a non-static URL (the 0.4.0 bug).
+ * `||` is safe and keeps `globalThis.__IMG2NUM_WASM_NAME__` working as a
+ * manual override for exotic setups.
+ */
+function wasmUrlPlugin() {
+  const LITERAL = 'new URL("img2num.wasm", import.meta.url)';
+  const MANGLED = 'new URL(globalThis.__IMG2NUM_WASM_NAME__ || "img2num.wasm", import.meta.url)';
+
+  return {
+    name: "img2num:wasm-url",
+    enforce: "pre",
+    transform(code, id) {
+      if (!id.includes("build-wasm") || !T.copyWasm) return null;
+      if (!code.includes("import.meta.url")) return null;
+
+      const patched = code.replace(/new URL\((["'])(img2num\.wasm)\1,\s*import\.meta\.url\)/g, MANGLED);
+      return patched === code ? null : { code: patched, map: null };
+    },
+    generateBundle(_, bundle) {
+      if (!T.copyWasm) return;
+
+      // Tolerant match: quote style and whitespace may be normalized by the
+      // bundler even when the expression itself survives.
+      const mangledRe = /new URL\(\s*globalThis\.__IMG2NUM_WASM_NAME__\s*\|\|\s*(["'])img2num\.wasm\1\s*,\s*import\.meta\.url\s*\)/g;
+
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== "chunk") continue;
+        chunk.code = chunk.code.replace(mangledRe, LITERAL);
+      }
+
+      // Guard: the browser ES build must ship the bundler-detectable literal.
+      // Fails the build loudly instead of shipping a consumer-breaking chunk.
+      if (TARGET === "browser") {
+        const hasLiteral = Object.values(bundle).some((c) => c.type === "chunk" && c.code.includes(LITERAL));
+        if (!hasLiteral) {
+          throw new Error("[img2num] wasm URL literal missing from browser bundle — consumers' bundlers won't detect the asset.");
+        }
+      }
+    },
+  };
+}
+
 const FILE_NAMES = {
   es: "img2num.js",
   cjs: "img2num.cjs",
@@ -111,7 +151,7 @@ const FILE_NAMES = {
 };
 
 export default defineConfig({
-  plugins: [preventWasmInlining(), copyWasmPlugin()],
+  plugins: [wasmUrlPlugin(), copyWasmPlugin()],
 
   build: {
     outDir: T.outDir ?? `dist/${TARGET}`,

--- a/packages/js/vite.config.js
+++ b/packages/js/vite.config.js
@@ -95,49 +95,60 @@ function copyWasmPlugin() {
  * Solution, in two phases:
  *   1. transform: mangle the literal into a non-static expression so
  *      lib-mode asset analysis can't inline it.
- *   2. generateBundle: after analysis is done, restore the literal in the
- *      emitted chunk so consumers' bundlers can see it.
+ *   2. generateBundle: after analysis is done, restore a bundler-detectable
+ *      form in the emitted chunk. The restored form is a TERNARY, not the
+ *      bare literal: the false branch is the exact literal (which consumer
+ *      bundlers detect and rewrite), while the true branch preserves
+ *      `globalThis.__IMG2NUM_WASM_NAME__` as a runtime override for exotic
+ *      setups (e.g. CDN-hosted wasm). Do not "simplify" the ternary away --
+ *      collapsing it to the literal silently kills the override.
  *
  * LOAD-BEARING CONSTRAINT: the mangled sentinel must be valid syntax at
- * build.target (es2020). Do NOT use `??=` or other ES2021+ operators here —
+ * build.target (es2020). Do NOT use `??=` or other ES2021+ operators here --
  * they get transpiled before generateBundle runs, the restore match fails
  * silently, and the published chunk ships a non-static URL (the 0.4.0 bug).
- * `||` is safe and keeps `globalThis.__IMG2NUM_WASM_NAME__` working as a
- * manual override for exotic setups.
+ * `||` is safe at es2020.
  */
 function wasmUrlPlugin() {
   const LITERAL = 'new URL("img2num.wasm", import.meta.url)';
   const MANGLED = 'new URL(globalThis.__IMG2NUM_WASM_NAME__ || "img2num.wasm", import.meta.url)';
+  const WASM_NAME = "globalThis.__IMG2NUM_WASM_NAME__";
+  // Override wins when set; otherwise the literal branch is what consumer
+  // bundlers statically detect. Bundlers match the expression node, so the
+  // literal being inside a ternary branch does not defeat detection.
+  const RESTORED = `(${WASM_NAME} ? new URL(${WASM_NAME}, import.meta.url) : ${LITERAL})`;
+
+  // The pattern only exists in the ES6 web glue; node glue resolves via
+  // __dirname and standalone glue via document.currentScript. Restricting to
+  // the browser target makes that a structural guarantee instead of a
+  // coincidence of glue contents.
+  if (TARGET !== "browser") return { name: "img2num:wasm-url" };
 
   return {
     name: "img2num:wasm-url",
     enforce: "pre",
     transform(code, id) {
-      if (!id.includes("build-wasm") || !T.copyWasm) return null;
+      if (!id.includes("build-wasm")) return null;
       if (!code.includes("import.meta.url")) return null;
 
       const patched = code.replace(/new URL\((["'])(img2num\.wasm)\1,\s*import\.meta\.url\)/g, MANGLED);
       return patched === code ? null : { code: patched, map: null };
     },
     generateBundle(_, bundle) {
-      if (!T.copyWasm) return;
-
       // Tolerant match: quote style and whitespace may be normalized by the
       // bundler even when the expression itself survives.
       const mangledRe = /new URL\(\s*globalThis\.__IMG2NUM_WASM_NAME__\s*\|\|\s*(["'])img2num\.wasm\1\s*,\s*import\.meta\.url\s*\)/g;
 
       for (const chunk of Object.values(bundle)) {
         if (chunk.type !== "chunk") continue;
-        chunk.code = chunk.code.replace(mangledRe, LITERAL);
+        chunk.code = chunk.code.replace(mangledRe, RESTORED);
       }
 
       // Guard: the browser ES build must ship the bundler-detectable literal.
       // Fails the build loudly instead of shipping a consumer-breaking chunk.
-      if (TARGET === "browser") {
-        const hasLiteral = Object.values(bundle).some((c) => c.type === "chunk" && c.code.includes(LITERAL));
-        if (!hasLiteral) {
-          throw new Error("[img2num] wasm URL literal missing from browser bundle — consumers' bundlers won't detect the asset.");
-        }
+      const hasLiteral = Object.values(bundle).some((c) => c.type === "chunk" && c.code.includes(LITERAL));
+      if (!hasLiteral) {
+        throw new Error("[img2num] wasm URL literal missing from browser bundle -- consumers' bundlers won't detect the asset.");
       }
     },
   };


### PR DESCRIPTION
## Summary

Fixes a regression in `0.4.0` where the published browser ES build (`dist/browser/img2num.js`) ships a wasm URL that downstream bundlers cannot statically analyze. Any consumer bundling `img2num` with Vite, webpack 5, Rollup, or Parcel gets a runtime 404 (`GET .../assets/img2num.wasm`) followed by `RuntimeError: Aborted(both async and sync fetching of the wasm failed)`.

## Root cause

Vite's lib mode inlines `new URL("img2num.wasm", import.meta.url)` as a data URL (ignoring `assetsInlineLimit`), so the build previously mangled the expression into a non-static form to defeat that analysis:

```js
new URL(globalThis.__IMG2NUM_WASM_NAME__ ??= "img2num.wasm", import.meta.url)
```

That mangled form shipped in the published output. The same property that defeats our lib-mode inlining also blinds **consumers'** bundlers — the exact literal `new URL("<file>", import.meta.url)` is the pattern they rely on to detect, emit, hash, and rewrite the wasm asset in app builds. With it gone, the URL resolves at runtime against the consumer's chunk path, where no wasm exists.

The standalone IIFE/UMD builds are unaffected (`SINGLE_FILE=1`, wasm embedded), which is why the CDN `<script>` path kept working while bundled consumers broke. Node builds resolve via the glue's `__dirname` path and are also unaffected.

## Fix

`preventWasmInlining` is replaced by a two-phase `wasmUrlPlugin`:

1. **`transform`** — mangle the literal into `new URL(globalThis.__IMG2NUM_WASM_NAME__ || "img2num.wasm", import.meta.url)` so lib-mode asset analysis can't inline it.
2. **`generateBundle`** — after analysis is complete, restore the exact literal in the emitted chunk so consumers' bundlers can see it.

Notes on the implementation:

- The sentinel uses `||` instead of `??=`. Logical assignment is ES2021; with `build.target: "es2020"` it gets transpiled before `generateBundle` runs, the restore match fails silently, and the broken expression ships again. This constraint is documented inline.
- The restore match is regex-based (tolerant of quote/whitespace normalization), not an exact-string compare.
- A guard throws if the browser build's output lacks the literal, so this class of regression fails the build instead of publishing. This check would have caught `0.4.0`.
- `globalThis.__IMG2NUM_WASM_NAME__` still works as a manual URL override for exotic setups.

## Result for consumers

Bundling `img2num` is now zero-config: the bundler detects the literal, emits the wasm into the app's assets with a hash, and rewrites the URL. No `?url` imports, no globals, no entry-file ordering requirements. Plain `<script type="module">` consumers copying `img2num.js` + `img2num.wasm` side by side continue to get correct relative resolution.

## Verification

- `grep -c 'new URL("img2num.wasm", import.meta.url)' packages/js/dist/browser/img2num.js` → `1` (literal present in published output; was `0` on `0.4.0`).
- Rebuilt `example-apps/react-js` with **no app-side changes**: build now emits `assets/img2num-MjQHcrHS.wasm` (550 kB) and the vectorization flow works in the served docs build.
- `esm` example unchanged (sibling `img2num.wasm`, relative resolution); `iife`/`umd` examples unchanged (embedded wasm, nothing to fetch); node builds unchanged.

## Follow-up (post-merge)

- [ ] `npm deprecate img2num@0.4.0 "wasm