### PR TITLE
fix(js): load webgpu via dynamic import and fall back to CPU when unavailable

### DIFF
--- a/packages/js/src/target/node/webgpu.js
+++ b/packages/js/src/target/node/webgpu.js
@@ -1,5 +1,3 @@
-import { create } from "webgpu";
-
 let gpuInitPromise;
 
 /**
@@ -11,6 +9,11 @@ let gpuInitPromise;
  * one does not already exist on `globalThis.navigator.gpu`. The initialized
  * instance is cached so repeated calls return the same promise.
  *
+ * The `webgpu` package is ESM-only and MUST be loaded via dynamic `import()`.
+ * A static `import { create } from "webgpu"` compiles to a top-level
+ * `require("webgpu")` in the CJS build, which throws ERR_REQUIRE_ESM on
+ * Node < 22.12.
+ *
  * @async
  * @function initWebGPU
  * @returns {Promise<GPU>} The initialized WebGPU implementation.
@@ -19,12 +22,13 @@ let gpuInitPromise;
 export async function initWebGPU() {
   if (globalThis.navigator?.gpu) return globalThis.navigator.gpu;
   if (!gpuInitPromise) {
-    gpuInitPromise = Promise.resolve().then(() => {
+    gpuInitPromise = (async () => {
+      const { create } = await import("webgpu");
       const nativeGpu = create(["backend=vulkan"]);
       globalThis.navigator ??= {};
       globalThis.navigator.gpu = nativeGpu;
       return nativeGpu;
-    });
+    })();
   }
   return gpuInitPromise;
 }

--- a/packages/js/src/target/node/webgpu.js
+++ b/packages/js/src/target/node/webgpu.js
@@ -10,9 +10,8 @@ let gpuInitPromise;
  * instance is cached so repeated calls return the same promise.
  *
  * The `webgpu` package is ESM-only and MUST be loaded via dynamic `import()`.
- * A static `import { create } from "webgpu"` compiles to a top-level
- * `require("webgpu")` in the CJS build, which throws ERR_REQUIRE_ESM on
- * Node < 22.12.
+ * A static import compiles to a top-level CommonJS require of the package
+ * in the CJS build, which throws ERR_REQUIRE_ESM on Node < 22.12.
  *
  * @async
  * @function initWebGPU

--- a/packages/js/src/wasmModule.js
+++ b/packages/js/src/wasmModule.js
@@ -40,7 +40,11 @@ export async function initWasmModule() {
           const { initWebGPU } = await import("./target/node/webgpu.js");
           await initWebGPU();
         } catch (err) {
-          console.error(`[Img2Num wasmModule] WebGPU init error: ${err}\n\nImg2Num should fall back to CPU.`);
+          console.error(`[Img2Num wasmModule] WebGPU init error: ${err}\n\nFalling back to CPU.`);
+          // The Emscripten glue dereferences `navigator` unconditionally; a
+          // stub that fails the adapter request cleanly routes to the CPU path.
+          globalThis.navigator ??= {};
+          globalThis.navigator.gpu ??= { requestAdapter: async () => null };
         }
       }
 

--- a/packages/js/vite.config.js
+++ b/packages/js/vite.config.js
@@ -85,7 +85,7 @@ function copyWasmPlugin() {
 }
 
 function cjsWebgpuGuard() {
-  // Only the CJS node build can regress into require("webgpu"); the other
+  // Only the CJS node build can regress into a require of webgpu; the other
   // targets either keep real import() (node-esm) or exclude webgpu entirely.
   if (TARGET !== "node-cjs") return { name: "img2num:cjs-webgpu-guard" };
   return {
@@ -93,13 +93,14 @@ function cjsWebgpuGuard() {
     generateBundle(_, bundle) {
       for (const chunk of Object.values(bundle)) {
         if (chunk.type !== "chunk") continue;
-        // Strip comments before matching; the source JSDoc mentions
-        // require("webgpu") when documenting this very bug.
-        const code = chunk.code.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, "");
-        if (/require\(\s*["']webgpu["']\s*\)/.test(code)) {
-          throw new Error(
-            `[img2num] ${chunk.fileName} contains require("webgpu") -- throws ERR_REQUIRE_ESM on Node < 22.12. The dynamic import() was lowered; see src/target/node/webgpu.js.`
-          );
+        // Matched against raw chunk code, no comment stripping: stripping
+        // comments with a regex mis-lexes // inside string literals (URLs)
+        // and can hide a real call. Instead, the source is kept free of the
+        // literal in comments (see src/target/node/webgpu.js JSDoc), so any
+        // match here is executable code. A future comment reintroducing the
+        // literal fails the build loudly, which is the safe direction.
+        if (/require\(\s*["']webgpu["']\s*\)/.test(chunk.code)) {
+          throw new Error(`[img2num] ${chunk.fileName} contains a require of "webgpu" -- throws ERR_REQUIRE_ESM on Node < 22.12. The dynamic import() was lowered; see src/target/node/webgpu.js.`);
         }
       }
     },

--- a/packages/js/vite.config.js
+++ b/packages/js/vite.config.js
@@ -84,6 +84,28 @@ function copyWasmPlugin() {
   };
 }
 
+function cjsWebgpuGuard() {
+  // Only the CJS node build can regress into require("webgpu"); the other
+  // targets either keep real import() (node-esm) or exclude webgpu entirely.
+  if (TARGET !== "node-cjs") return { name: "img2num:cjs-webgpu-guard" };
+  return {
+    name: "img2num:cjs-webgpu-guard",
+    generateBundle(_, bundle) {
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== "chunk") continue;
+        // Strip comments before matching; the source JSDoc mentions
+        // require("webgpu") when documenting this very bug.
+        const code = chunk.code.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, "");
+        if (/require\(\s*["']webgpu["']\s*\)/.test(code)) {
+          throw new Error(
+            `[img2num] ${chunk.fileName} contains require("webgpu") -- throws ERR_REQUIRE_ESM on Node < 22.12. The dynamic import() was lowered; see src/target/node/webgpu.js.`
+          );
+        }
+      }
+    },
+  };
+}
+
 /**
  * Ships a bundler-detectable wasm URL in the published output.
  *
@@ -162,7 +184,7 @@ const FILE_NAMES = {
 };
 
 export default defineConfig({
-  plugins: [wasmUrlPlugin(), copyWasmPlugin()],
+  plugins: [wasmUrlPlugin(), copyWasmPlugin(), cjsWebgpuGuard()],
 
   build: {
     outDir: T.outDir ?? `dist/${TARGET}`,


### PR DESCRIPTION
## Problem

`require("img2num")` on Node 18/20 crashed during `imageToSvg()`:
[Img2Num wasmModule] WebGPU init error: Error [ERR_REQUIRE_ESM]: require() of ES Module .../node_modules/webgpu/index.js from .../img2num/dist/node/webgpu-DnHE7-PM.cjs not supported.
...
Error: [Img2Num wasmClient] Error: navigator is not defined`

Found while building the Node.js CJS example sandbox against the published v0.4.1.

## Causes

**1. `require()` of the ESM-only `webgpu` package.**
`src/target/node/webgpu.js` used a static `import { create } from "webgpu"`. In the node-cjs target, Rolldown compiles static imports of externals to a top-level `require("webgpu")`. The `webgpu` package is ESM-only, so this throws `ERR_REQUIRE_ESM` on Node < 22.12. Node ≥ 22.12 supports `require(esm)` natively, which is why the bug never reproduced in the dev container (Node 22.16) — our `engines` field says `>=18`.

**2. The CPU fallback didn't fall back.**
When the webgpu import rejects (this bug, or the optional dependency simply not installed — `--ignore-optional`, unsupported platform), `initWasmModule` logged *"Img2Num should fall back to CPU"* and then initialized the wasm module anyway with no `globalThis.navigator`. The Emscripten glue's `_emwgpuInstanceRequestAdapter` dereferences bare `navigator`, so the conversion crashed instead of using the CPU.

## Fixes

- `src/target/node/webgpu.js`: load `webgpu` via dynamic `import()` inside `initWebGPU()`. Rolldown preserves it as a genuine `import()` in the CJS output, which can load ESM from CJS on all supported Node versions.
- `src/wasmModule.js`: on webgpu init failure, install a stub `navigator.gpu` whose `requestAdapter()` resolves `null`. The glue's adapter probe then fails cleanly and the CPU path engages — same flow as a GPU-less machine with webgpu installed.
- `vite.config.js`: new `cjsWebgpuGuard` plugin (node-cjs target only) fails the build in `generateBundle` if any emitted chunk contains an executable `require("webgpu")` (comments stripped before matching). This is the same guard pattern as `wasmUrlPlugin`: the failure mode is the bundler rewriting load-bearing code during emit, which no source-level check can catch — see the v0.4.0 wasm URL inlining regression.

## Verification

- Guard: reintroducing the static import makes `pnpm build:node-cjs` fail with the guard error. Clean build passes all four targets. (Note: `emptyOutDir: false` on node-cjs means the guard also scans stale chunks in `dist/node/` — run `just clean packages-js` if it flags a hash that no longer builds.)
- Fallback (bug 2): with `node_modules/webgpu` removed, `just console-js-esm` and `just console-js-cjs` both print "Falling back to CPU", produce the SVG, and exit 0.
- CJS GPU path (bug 1): with webgpu present, `just console-js-cjs` now initializes the adapter/device identically to the ESM entry.
- Emitted chunk contains `import("webgpu")` and no executable `require("webgpu")`.

## Out of scope

On machines with working Vulkan, both entries crash *after* successful SVG output during process teardown (nondeterministic: SIGSEGV / pthread_mutex assertion / futex error). This is Dawn teardown racing process exit in the upstream `webgpu` package, pre-exists this change, and only affects the GPU path at exit. Tracked separately.