### PR TITLE
fix(py): switch sdist to explicit inclusion mode and exclude Dawn test corpora

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "img2num"
-dynamic = ["version"] # see tool.scikit-buil
+dynamic = ["version"] # derived via [[tool.dynamic-metadata]] below
 description = "A fast and accurate raster image to SVG conversion library"
 requires-python = ">=3.10"
 license = { text = "MIT" }
@@ -30,7 +30,7 @@ Changelog     = "https://img2num.dev/changelog/py/"
 
 [build-system]
 requires = [
-  "scikit-build-core>=0.10",
+  "scikit-build-core>=1.0",
   "pybind11>=2.10",
   "numpy>=2.0",
   "pybind11-stubgen>=2.5.5,<3",
@@ -45,12 +45,34 @@ cmake.args = [
   "-DIMG2NUM_BUILD_EXAMPLES=OFF",
 ]
 wheel.packages = ["img2num"]
+sdist.inclusion-mode = "explicit"
 sdist.include = [
+  "pyproject.toml",
+  "LICENSE",
   "CMakeLists.txt",
   "core/**",
   "bindings/py/**",
   "packages/py/**",
-  "third_party/**"
+  "third_party/dawn/**",
+]
+sdist.exclude = [
+  # Local build output; explicit mode does not read .gitignore, so these
+  # must be excluded here.
+  "packages/py/build/",
+  "packages/py/build-py/",
+  "third_party/dawn/build/",
+  # Dawn test corpora: never consumed by any build; the vk-gl-cts tree makes
+  # tar extraction fragile (deterministic CI unpack failure, PR #562).
+  "third_party/dawn/test/",
+  "third_party/dawn/testing/",
+  "third_party/dawn/webgpu-cts/",
+  # WebGPU CTS GN metadata: 43 MB test_list.txt + 8 MB cache tarball.
+  "third_party/dawn/third_party/gn/",
+  # Opt-in macOS toolchain dir (per its README); contains the tree's only
+  # dangling symlink (ranlib -> libtool).
+  "third_party/dawn/src/cmake/HermeticXcode/",
+  # Dangling submodule gitlink; VCS metadata does not belong in an sdist.
+  "third_party/dawn/.git",
 ]
 
 # Derive version from version definition in packages/py/pyproject.toml


### PR DESCRIPTION
The default inclusion mode leaves include/exclude collisions unspecified: sdist.include "third_party/dawn/**" overlapped every Dawn exclude pattern, producing inconsistent tarballs from the same config (35k vs 93k entries across otherwise identical builds). Explicit mode documents that exclude is applied after include, making sdist contents deterministic. Explicit mode also ignores .gitignore, so local build directories are excluded here too.

Excludes Dawn's test corpora (~60k files never consumed by any build) whose vk-gl-cts tree caused the deterministic sdist unpack failure in CI (see the Build Python failures on #562), the webgpu-cts GN metadata (43 MB test_list.txt plus an 8 MB cache tarball, both also present in the currently published PyPI sdist), the opt-in HermeticXcode macOS toolchain dir that contains the tree's only dangling symlink, and the dangling dawn/.git submodule gitlink.

Result: 105 MB / 93k entries down to 6.5 MB / ~5k entries. The wheel builds from the sdist end-to-end and the console example runs on the GPU path.

inclusion-mode = "explicit" requires scikit-build-core >= 1.0, so the build-system floor is bumped accordingly.
