### PR TITLE
fix: prevent integer overflow in process_overlapping_edges

### DIFF
--- a/core/src/internal/graph.cpp
+++ b/core/src/internal/graph.cpp
@@ -145,7 +145,7 @@ void Graph::discover_edges(
 
 void Graph::process_overlapping_edges() {
     // 1. Build the Global Label Map ONCE (0 = background, else = node->id())
-    std::vector<int32_t> label_map(m_width * m_height, 0);
+    std::vector<int32_t> label_map(static_cast<size_t>(m_width) * static_cast<size_t>(m_height), 0);
 
     for (const Node_ptr& n : get_nodes()) {
         if (n->area() == 0)


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## Changes & Reason

### Changes

Cast `m_width` and `m_height` to `size_t` before multiplication in `Graph::process_overlapping_edges()`.

### Reason

Prevents potential integer overflow during 32-bit multiplication before converting to `std::size_t`.

## Related 
Fixes: #572

## Testing & Verification
<!--How these changes were tested-->

## Additional Resources
<!-- Extra information, e.g. screenshots -->
