### PR TITLE
fix: prevent int overflow in Graph::analyzeJunctions vector size calculation

### DIFF
--- a/core/src/internal/graph.cpp
+++ b/core/src/internal/graph.cpp
@@ -221,7 +221,7 @@ void Graph::process_overlapping_edges() {
 }
 
 std::vector<uint8_t> Graph::analyzeJunctions(const std::vector<uint8_t>& skel, int w, int h) {
-    std::vector<uint8_t> junction_map(w * h, 0);
+    std::vector<uint8_t> junction_map(static_cast<size_t>(w) * h, 0);
 
     // 8-Neighbor Order (Clockwise)
     // P9 P2 P3


### PR DESCRIPTION
<!--
Thanks for contributing to Img2Num!

Please note that by submitting this pull request to **Img2Num**, you confirm that:
1. You have read and agree to the contribution guidelines.
2. Your submission complies with our licensing, including attribution and redistribution rules.
3. All code, documentation, and other contributions are your original work or you have permission to submit them.
4. You understand that your contributions may be reviewed and edited for consistency and quality before merging.
 -->

## Changes & Reason

### Changes
Added `static_cast<size_t>` to one of the integer arguments of an expression

### Reason
To prevent integer overflow before vector (`junction_map`) construction.

## Related Issues
<!--Related issues (auto close when this PR merges)-->
Fixes: #570 

## Testing & Verification
<!--How these changes were tested-->
The project was built and ran with no issues.
