### PR TITLE
refactor(js): make TARGET lookup a strict allowlist

### DIFF
--- a/packages/js/vite.config.js
+++ b/packages/js/vite.config.js
@@ -14,6 +14,7 @@ const TARGETS = {
     isNode: false,
     // Copy the external .wasm next to the bundle.
     copyWasm: "required",
+    outDir: "dist/browser",
   },
 
   standalone: {
@@ -27,6 +28,7 @@ const TARGETS = {
     isNode: false,
     // Absent when SINGLE_FILE=1, present when SINGLE_FILE=0
     copyWasm: "optional",
+    outDir: "dist/standalone",
   },
 
   "node-esm": {
@@ -56,16 +58,16 @@ const TARGETS = {
   },
 };
 
-const T = TARGETS[TARGET];
-if (!T) {
+if (!Object.hasOwn(TARGETS, TARGET)) {
   throw new Error(`[img2num] Unknown TARGET "${TARGET}". Expected one of: ${Object.keys(TARGETS).join(", ")}`);
 }
+const T = TARGETS[TARGET];
 
 // Single sources of truth for the paths that used to be re-derived in each
 // plugin: glue input dir, output dir, and the remediation hint shown by
 // every "wasm build missing" error.
 const glueDir = path.join(here, "build-wasm", T.glue);
-const outDir = T.outDir ?? `dist/${TARGET}`;
+const outDir = T.outDir;
 const WASM_BUILD_HINT = "Run the CMake wasm build first (just build js, or emcmake cmake -B build-wasm && cmake --build build-wasm).";
 
 // Config-time guard: a missing build-wasm/ otherwise dies later as a cryptic


### PR DESCRIPTION
Closes #580

Replaces the `TARGETS[TARGET]` lookup with `Object.hasOwn(TARGETS, TARGET)`
so prototype keys (e.g. TARGET=constructor) are rejected with the intended
"Unknown TARGET" error instead of falling through with a confusing
missing-directory error. Also makes `outDir` explicit for the `browser`
and `standalone` targets so TARGET is never used to build a filesystem
path — resolves the CodeQL js/path-injection alert.

Verified locally:
- TARGET=constructor → "Unknown TARGET" error, as expected
- TARGET=browser (default path) → fails at the pre-existing wasm-missing
  guard, unchanged behavior; full build not run locally since I didn't
  set up the Emscripten dev container for this small change
