### PR TITLE
docs(website): add contributor count to homepage stats bar

### DIFF
--- a/docs/lib/githubStats.js
+++ b/docs/lib/githubStats.js
@@ -1,0 +1,25 @@
+const REPO = "Ryan-Millard/Img2Num";
+
+// Works in the browser and at build time (Node 18+).
+// The optional token is only used at build time, where CI provides one.
+export async function fetchContributorCount({ token } = {}) {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/contributors?per_page=1`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+
+    if (!res.ok) return null;
+
+    const link = res.headers.get("link");
+
+    if (link) {
+      const match = link.match(/[?&]page=(\d+)>;\s*rel="last"/);
+      return match ? Number(match[1]) : null;
+    }
+
+    const body = await res.json();
+    return body.length;
+  } catch {
+    return null;
+  }
+}

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from "react";
 import Hedgehog from "../components/Hedgehog";
 import styles from "./index.module.css";
 import CodeBlock from "@theme/CodeBlock";
+import { fetchContributorCount } from "../../lib/githubStats";
 
 function RasterToSvgDemo() {
   return (
@@ -42,6 +43,7 @@ function HeroSection() {
   const [stats, setStats] = useState({
     stars: null,
     forks: null,
+    contributors: null,
   });
 
   useEffect(() => {
@@ -49,13 +51,20 @@ function HeroSection() {
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data) {
-          setStats({
+          setStats((prev) => ({
+            ...prev,
             stars: data.stargazers_count,
             forks: data.forks_count,
-          });
+          }));
         }
       })
       .catch(() => {});
+
+    fetchContributorCount().then((count) => {
+      if (count !== null) {
+        setStats((prev) => ({ ...prev, contributors: count }));
+      }
+    });
   }, []);
 
   return (
@@ -106,6 +115,10 @@ function HeroSection() {
             <div className={styles.stat}>
               <span className={styles.statNum}>⑂ {stats.forks !== null ? stats.forks : "—"}</span>
               <span className={styles.statLabel}>forks</span>
+            </div>
+            <div className={styles.stat}>
+              <span className={styles.statNum}>◉ {stats.contributors !== null ? stats.contributors : "—"}</span>
+              <span className={styles.statLabel}>contributors</span>
             </div>
             <div className={styles.stat}>
               <span className={styles.statNum}>C++/C/Py/JS</span>


### PR DESCRIPTION
Closes #595

## Changes
- Added `docs/lib/githubStats.js` with `fetchContributorCount()`, using the Link-header trick described in the issue
- Added a third stat (contributors) to the homepage stats bar, next to stars and forks

## Verification
- Confirmed the contributors count renders correctly (matches GitHub's contributor count)
- Confirmed graceful failure handling: simulated a failed request and verified the stat falls back to `—` with no console errors, and doesn't display a wrong low number